### PR TITLE
[DE-435] Recibir el modelo del contenido Unlayer sin modificaciones

### DIFF
--- a/Doppler.HtmlEditorApi/Infrastructure/CampaignContentRequest.cs
+++ b/Doppler.HtmlEditorApi/Infrastructure/CampaignContentRequest.cs
@@ -1,7 +1,8 @@
+using System.Text.Json;
 using Doppler.HtmlEditorApi.Model;
 
 public class CampaignContentRequest
 {
     public string Content { get; set; }
-    public ContentModel Meta { get; set; }
+    public JsonElement Meta { get; set; }
 }

--- a/Doppler.HtmlEditorApi/Infrastructure/Repository.cs
+++ b/Doppler.HtmlEditorApi/Infrastructure/Repository.cs
@@ -54,8 +54,8 @@ WHERE co.IdCampaign = @campaignId  AND u.Email = @accountName AND co.EditorType 
                     databaseExec = @"UPDATE Content SET Content = @htmlContent, Meta = @metaModel WHERE IdCampaign = @campaignId";
                 }
 
-                var modelSerialize = JsonSerializer.Serialize(request.Meta);
-                var result = await connection.ExecuteAsync(databaseExec, new { campaignId, htmlContent = request.Content, metaModel = modelSerialize });
+                var metaModel = request.Meta.ToString();
+                var result = await connection.ExecuteAsync(databaseExec, new { campaignId, htmlContent = request.Content, metaModel });
                 return result > 0;
             }
         }


### PR DESCRIPTION
Recibimos el modelo de Unlayer sin modificaciones en la data y sin tener en cuanta la estructura de `ContentModel` que tenemos definida en la API, el objetivo es no perder ningún dato generado por Unlayer.

<s>Se decide recibir un objeto **JSON** por encima de un dato tipo **String** para quitar al cliente _(quien hace la petición)_ la responsabilidad de hacer escape de los datos, de esta manera en la petición viaja un objeto JSON y la API decide como hacer escape de la data entrante.</s>
El cliente _(quien hace la petición)_ puede enviar un **JSON** o un objeto JSON como **string**

### Ejemplo: 

- Meta JSON: `{"prop": "value"}`
- Meta string: `"{\"prop\":\"value\"}"`