### PR TITLE
refactor: refactor ContentRow into a record in place of a class

### DIFF
--- a/Doppler.HtmlEditorApi/Infrastructure/ContentRow.cs
+++ b/Doppler.HtmlEditorApi/Infrastructure/ContentRow.cs
@@ -1,9 +1,1 @@
-using Doppler.HtmlEditorApi.Model;
-
-public class ContentRow
-{
-    public string Content { get; set; }
-    public string Meta { get; set; }
-    public int IdCampaign { get; set; }
-    public int EditorType { get; set; }
-}
+public record ContentRow(string content, string meta, int idCampaign, int editorType);

--- a/Doppler.HtmlEditorApi/Infrastructure/Repository.cs
+++ b/Doppler.HtmlEditorApi/Infrastructure/Repository.cs
@@ -30,11 +30,11 @@ WHERE co.IdCampaign = @campaignId  AND u.Email = @accountName AND co.EditorType 
                     return null;
                 }
 
-                using var doc = JsonDocument.Parse(result.Meta);
+                using var doc = JsonDocument.Parse(result.meta);
 
                 return new CampaignContent(
                     meta: doc.RootElement,
-                    htmlContent: result.Content);
+                    htmlContent: result.content);
             }
         }
 


### PR DESCRIPTION
Very minor change to keep the code style aligned with #21.

It will force us to define all properties and make the object read-only. Record types are really convenient for this class of DTOs.