### PR TITLE
build: reduce verifications for publishing to INT environment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,19 +1,28 @@
 pipeline {
     agent any
     stages {
-        stage('Verify git commit conventions') {
-            steps {
-                sh 'sh ./gitlint.sh'
+        stage('Verifications') {
+            when {
+                not {
+                    branch 'INT'
+                }
             }
-        }
-        stage('Verify Format') {
-            steps {
-                sh 'docker build --target verify-format .'
-            }
-        }
-        stage('Verify .sh files') {
-            steps {
-                sh 'docker build --target verify-sh .'
+            stages {
+                stage('Verify git commit conventions') {
+                    steps {
+                        sh 'sh ./gitlint.sh'
+                    }
+                }
+                stage('Verify Format') {
+                    steps {
+                        sh 'docker build --target verify-format .'
+                    }
+                }
+                stage('Verify .sh files') {
+                    steps {
+                        sh 'docker build --target verify-sh .'
+                    }
+                }
             }
         }
         stage('Restore') {
@@ -27,6 +36,11 @@ pipeline {
             }
         }
         stage('Test') {
+            when {
+                not {
+                    branch 'INT'
+                }
+            }
             steps {
                 sh 'docker build --target test .'
             }


### PR DESCRIPTION
Hi team! 

It is to easily release working progress branches to INT.

When the branch is INT, it will avoid:
* Verify git commit conventions
* Verify Format
* Verify .sh files
* Test

What do you think?