### PR TITLE
DE-445 - Only update own campaigns

### DIFF
--- a/Doppler.HtmlEditorApi/Infrastructure/Repository.cs
+++ b/Doppler.HtmlEditorApi/Infrastructure/Repository.cs
@@ -50,6 +50,8 @@ WHERE u.Email = @accountName
                     throw new ApplicationException($"CampaignId {campaignId} does not exists or belongs to another user than {accountName}");
                 }
 
+                // NOTE: It is updating even when the EditorType is different than 5
+
                 var query = campaignStatus.ContentExists
                     ? @"UPDATE Content SET Content = @Content, Meta = @Meta, EditorType = @EditorType WHERE IdCampaign = @IdCampaign"
                     : @"INSERT INTO Content (IdCampaign, Content, Meta, EditorType) VALUES (@IdCampaign, @Content, @Meta, @EditorType)";

--- a/Doppler.HtmlEditorApi/Infrastructure/Repository.cs
+++ b/Doppler.HtmlEditorApi/Infrastructure/Repository.cs
@@ -19,6 +19,7 @@ namespace Doppler.HtmlEditorApi.Infrastructure
         {
             using (var connection = await _connectionFactory.GetConnection())
             {
+                // TODO: Differentiate result when the campaign does not existe, is from another user or the campaign exists but content does not
                 var databaseQuery = @"SELECT co.IdCampaign, co.Content, co.EditorType, co.Meta FROM Content co
 JOIN Campaign ca ON ca.IdCampaign = co.IdCampaign
 JOIN [User] u ON u.IdUser = ca.IdUser


### PR DESCRIPTION
Hi team! 

I think that this implementation is safer and more predictable.

---

### Escenario A

* Campaña: _propia_
* Contenido: _existe_
* Tipo de contenido: _unlayer (5)_

➡ Se actualiza la fila (como antes)

### Escenario B

* Campaña: _propia_
* Contenido: _no existe_
* Tipo de contenido: _N/A_

➡ Se inserta la fila (como antes)

### Escenario C1

* Campaña: _de otro usuario_
* Contenido: _existe_
* Tipo de contenido: _unlayer (5)_

➡ Error porque "la campaña no existe o pertenece a otro usuario" (~ similar al comportamiento anterior)

### Escenario C2

* Campaña: _de otro usuario_
* Contenido: _existe_
* Tipo de contenido: _otro_

➡ Error porque "la campaña no existe o pertenece a otro usuario" (~ similar al comportamiento anterior)

### Escenario D

* Campaña: _propia_
* Contenido: _existe_
* Tipo de contenido: _otro_

➡ Se actualizará el contenido y tipo (cambio de comportamiento)

⚠️ Cuidado, es discutible si este comportamiento es el esperado.

### Escenario E

* Campaña: _de otro usuario_
* Contenido: _no existe_
* Tipo de contenido: _N/A_

➡ Error porque "la campaña no existe o pertenece a otro usuario" (diferente al comportamiento anterior)