### PR TITLE
Check if campaign exists, belongs to account and has content

### DIFF
--- a/Doppler.HtmlEditorApi/Controllers/CampaignsController.cs
+++ b/Doppler.HtmlEditorApi/Controllers/CampaignsController.cs
@@ -31,7 +31,7 @@ namespace Doppler.HtmlEditorApi.Controllers
 
             if (contentRow == null)
             {
-                return new NotFoundObjectResult("Campaign not found");
+                return new NotFoundObjectResult("Campaign not found or belongs to a different account");
             }
 
             using var doc = JsonDocument.Parse(contentRow.Meta);

--- a/Doppler.HtmlEditorApi/Infrastructure/ContentRow.cs
+++ b/Doppler.HtmlEditorApi/Infrastructure/ContentRow.cs
@@ -6,4 +6,18 @@ public class ContentRow
     public string Meta { get; set; }
     public int IdCampaign { get; set; }
     public int EditorType { get; set; }
+    public static ContentRow CreateEmpty(int campaignId)
+    {
+        return new ContentRow()
+        {
+            Content = "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional //EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\"><html xmlns=\"http://www.w3.org/1999/xhtml\" xmlns:v=\"urn:schemas-microsoft-com:vml\" xmlns:o=\"urn:schemas-microsoft-com:office:office\"><head> <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"> <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\"> <meta name=\"x-apple-disable-message-reformatting\"> <meta http-equiv=\"X-UA-Compatible\" content=\"IE=edge\"> <title></title></head><body></body></html>",
+            Meta = @"{
+""body"": {
+    ""rows"": []
+    }
+}",
+            IdCampaign = campaignId,
+            EditorType = 5
+        };
+    }
 }


### PR DESCRIPTION
This PR validates if

- Campaign exists
- Campaign belongs to account
- Campaign has content.

If doesn't exists or belongs to a different user, repository returns null.
If hasn't any content, repository returns an empty contentRow.
If none of these scenarios occurs, repository returns query result.