### PR TITLE
DE-450 - Preparation for the new content type

### DIFF
--- a/Doppler.HtmlEditorApi.Test/GetCampaignTest.cs
+++ b/Doppler.HtmlEditorApi.Test/GetCampaignTest.cs
@@ -161,7 +161,9 @@ namespace Doppler.HtmlEditorApi
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            Assert.True(contentModelResponse.meta.TryGetProperty("schemaVersion", out var resultSchemaVersionProp), "schemaVersion property is not present");
+            Assert.Matches("\"type\":\"unlayer\"", responseContent);
+            Assert.NotNull(contentModelResponse.meta);
+            Assert.True(contentModelResponse.meta.Value.TryGetProperty("schemaVersion", out var resultSchemaVersionProp), "schemaVersion property is not present");
             Assert.Equal(JsonValueKind.Number, resultSchemaVersionProp.ValueKind);
             Assert.True(resultSchemaVersionProp.TryGetInt32(out var resultSchemaVersion), "schemaVersion is not a valid Int32 value");
             Assert.Equal(expectedSchemaVersion, resultSchemaVersion);

--- a/Doppler.HtmlEditorApi.Test/GetCampaignTest.cs
+++ b/Doppler.HtmlEditorApi.Test/GetCampaignTest.cs
@@ -125,16 +125,13 @@ namespace Doppler.HtmlEditorApi
         {
             // Arrange
             var expectedSchemaVersion = 999;
-            ContentRow contentRow = new ContentRow()
-            {
-                Meta = JsonSerializer.Serialize(new
+            var contentRow = ContentRow.CreateUnlayerContentRow(
+                meta: JsonSerializer.Serialize(new
                 {
                     schemaVersion = expectedSchemaVersion
                 }),
-                Content = "<html></html>",
-                EditorType = 5,
-                IdCampaign = expectedIdCampaign
-            };
+                content: "<html></html>",
+                idCampaign: expectedIdCampaign);
 
             // TODO: consider to mock Dapper in place of IRepository
             var repositoryMock = new Mock<IRepository>();

--- a/Doppler.HtmlEditorApi/Controllers/CampaignsController.cs
+++ b/Doppler.HtmlEditorApi/Controllers/CampaignsController.cs
@@ -36,6 +36,7 @@ namespace Doppler.HtmlEditorApi.Controllers
 
             using var doc = JsonDocument.Parse(contentRow.Meta);
             var result = new CampaignContent(
+                type: ContentType.unlayer,
                 meta: doc.RootElement.Clone(),
                 htmlContent: contentRow.Content);
 

--- a/Doppler.HtmlEditorApi/Controllers/CampaignsController.cs
+++ b/Doppler.HtmlEditorApi/Controllers/CampaignsController.cs
@@ -34,10 +34,9 @@ namespace Doppler.HtmlEditorApi.Controllers
                 return new NotFoundObjectResult("Campaign not found or belongs to a different account");
             }
 
-            using var doc = JsonDocument.Parse(contentRow.Meta);
             var result = new CampaignContent(
                 type: ContentType.unlayer,
-                meta: doc.RootElement.Clone(),
+                meta: Utils.ParseAsJsonElement(contentRow.Meta),
                 htmlContent: contentRow.Content);
 
             return result;

--- a/Doppler.HtmlEditorApi/Controllers/CampaignsController.cs
+++ b/Doppler.HtmlEditorApi/Controllers/CampaignsController.cs
@@ -55,13 +55,10 @@ namespace Doppler.HtmlEditorApi.Controllers
         [HttpPut("/accounts/{accountName}/campaigns/{campaignId}/content")]
         public async Task<IActionResult> SaveCampaign(string accountName, int campaignId, CampaignContent campaignContent)
         {
-            var contentRow = new ContentRow()
-            {
-                Content = campaignContent.htmlContent,
-                Meta = campaignContent.meta.ToString(),
-                EditorType = 5,
-                IdCampaign = campaignId
-            };
+            var contentRow = ContentRow.CreateUnlayerContentRow(
+                content: campaignContent.htmlContent,
+                meta: campaignContent.meta.ToString(),
+                idCampaign: campaignId);
 
             await _repository.SaveCampaignContent(accountName, campaignId, contentRow);
             return new OkObjectResult($"La campaña '{campaignId}' del usuario '{accountName}' se guardó exitosamente ");

--- a/Doppler.HtmlEditorApi/Infrastructure/ContentRow.cs
+++ b/Doppler.HtmlEditorApi/Infrastructure/ContentRow.cs
@@ -1,23 +1,35 @@
-using Doppler.HtmlEditorApi.Model;
+namespace Doppler.HtmlEditorApi.Infrastructure;
 
 public class ContentRow
 {
+    private const int UNLAYER_EDITOR_TYPE = 5;
+
     public string Content { get; set; }
     public string Meta { get; set; }
     public int IdCampaign { get; set; }
     public int EditorType { get; set; }
+
     public static ContentRow CreateEmpty(int campaignId)
     {
-        return new ContentRow()
-        {
-            Content = "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional //EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\"><html xmlns=\"http://www.w3.org/1999/xhtml\" xmlns:v=\"urn:schemas-microsoft-com:vml\" xmlns:o=\"urn:schemas-microsoft-com:office:office\"><head> <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"> <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\"> <meta name=\"x-apple-disable-message-reformatting\"> <meta http-equiv=\"X-UA-Compatible\" content=\"IE=edge\"> <title></title></head><body></body></html>",
-            Meta = @"{
+        return ContentRow.CreateUnlayerContentRow(
+            content: "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional //EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\"><html xmlns=\"http://www.w3.org/1999/xhtml\" xmlns:v=\"urn:schemas-microsoft-com:vml\" xmlns:o=\"urn:schemas-microsoft-com:office:office\"><head> <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"> <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\"> <meta name=\"x-apple-disable-message-reformatting\"> <meta http-equiv=\"X-UA-Compatible\" content=\"IE=edge\"> <title></title></head><body></body></html>",
+            meta: @"{
 ""body"": {
     ""rows"": []
     }
 }",
-            IdCampaign = campaignId,
-            EditorType = 5
-        };
+            idCampaign: campaignId);
     }
+
+    public static ContentRow CreateUnlayerContentRow(string content, string meta, int idCampaign) =>
+        new ContentRow()
+        {
+            Content = content,
+            Meta = meta,
+            EditorType = UNLAYER_EDITOR_TYPE,
+            IdCampaign = idCampaign
+        };
+
+    public bool HasUnlayerEditorType => EditorType == UNLAYER_EDITOR_TYPE;
+
 }

--- a/Doppler.HtmlEditorApi/Infrastructure/DummyRepository.cs
+++ b/Doppler.HtmlEditorApi/Infrastructure/DummyRepository.cs
@@ -61,13 +61,10 @@ namespace Doppler.HtmlEditorApi.Infrastructure
 
         public Task<ContentRow> GetCampaignModel(string accountName, int campaignId)
         {
-            var contentRow = new ContentRow()
-            {
-                Meta = JsonSerializer.Serialize(_demoMeta),
-                Content = "<html></html>",
-                IdCampaign = campaignId,
-                EditorType = 5
-            };
+            var contentRow = ContentRow.CreateUnlayerContentRow(
+                meta: JsonSerializer.Serialize(_demoMeta),
+                content: "<html></html>",
+                idCampaign: campaignId);
 
             return Task.FromResult(contentRow);
         }

--- a/Doppler.HtmlEditorApi/Model/Campaign.cs
+++ b/Doppler.HtmlEditorApi/Model/Campaign.cs
@@ -12,13 +12,15 @@ public record CampaignContent(
     [Required]
     string htmlContent) : Content(type, meta, htmlContent), IValidatableObject
 {
+    private static HashSet<ContentType> _validContentTypes = new HashSet<ContentType>(Enum.GetValues<ContentType>());
+
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
     {
         if (type == (ContentType)0)
         {
             yield return new ValidationResult($"The {nameof(type)} field is required.", new[] { nameof(type) });
         }
-        else if (type != ContentType.unlayer)
+        else if (!_validContentTypes.Contains(type))
         {
             yield return new ValidationResult($"Content type '{type:G}' is not supported yet.");
         }

--- a/Doppler.HtmlEditorApi/Model/Campaign.cs
+++ b/Doppler.HtmlEditorApi/Model/Campaign.cs
@@ -7,17 +7,27 @@ namespace Doppler.HtmlEditorApi.Model;
 
 public record CampaignContent(
     [Required]
-    JsonElement meta,
+    ContentType type,
+    JsonElement? meta,
     [Required]
-    string htmlContent) : Content(meta, htmlContent), IValidatableObject
+    string htmlContent) : Content(type, meta, htmlContent), IValidatableObject
 {
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
     {
-        if (string.IsNullOrWhiteSpace(meta.ToString()))
+        if (type == (ContentType)0)
         {
-            yield return new ValidationResult($"The {nameof(meta)} field is required.", new[] { nameof(meta) });
+            yield return new ValidationResult($"The {nameof(type)} field is required.", new[] { nameof(type) });
         }
+        else if (type != ContentType.unlayer)
+        {
+            yield return new ValidationResult($"Content type '{type:G}' is not supported yet.");
+        }
+
+        if (type == ContentType.unlayer && (meta == null || string.IsNullOrWhiteSpace(meta.ToString())))
+        {
+            yield return new ValidationResult($"The {nameof(meta)} field is required for unlayer content.", new[] { nameof(meta) });
+        }
+
         yield break;
     }
 }
-

--- a/Doppler.HtmlEditorApi/Model/Content.cs
+++ b/Doppler.HtmlEditorApi/Model/Content.cs
@@ -2,4 +2,4 @@ using System.Text.Json;
 
 namespace Doppler.HtmlEditorApi.Model;
 
-public record Content(JsonElement meta, string htmlContent);
+public record Content(ContentType type, JsonElement? meta, string htmlContent);

--- a/Doppler.HtmlEditorApi/Model/ContentType.cs
+++ b/Doppler.HtmlEditorApi/Model/ContentType.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Doppler.HtmlEditorApi.Model;
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum ContentType
+{
+    unlayer = 5,
+}

--- a/Doppler.HtmlEditorApi/Model/Template.cs
+++ b/Doppler.HtmlEditorApi/Model/Template.cs
@@ -2,4 +2,4 @@ using System.Text.Json;
 
 namespace Doppler.HtmlEditorApi.Model;
 
-public record Template(string name, JsonElement meta, string htmlContent) : Content(meta, htmlContent);
+public record Template(ContentType type, string name, JsonElement? meta, string htmlContent) : Content(type, meta, htmlContent);

--- a/Doppler.HtmlEditorApi/Startup.cs
+++ b/Doppler.HtmlEditorApi/Startup.cs
@@ -29,7 +29,11 @@ namespace Doppler.HtmlEditorApi
         {
             services.AddProblemDetails();
             services.AddDopplerSecurity();
-            services.AddControllers();
+            services.AddControllers()
+                .AddJsonOptions(o =>
+                {
+                    o.JsonSerializerOptions.DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull;
+                });
             services.AddCors();
             services.AddSingleton<Weather.IWeatherForecastService, Weather.WeatherForecastService>();
             services.AddSingleton<Weather.DataService>();

--- a/Doppler.HtmlEditorApi/Utils.cs
+++ b/Doppler.HtmlEditorApi/Utils.cs
@@ -1,0 +1,12 @@
+using System.Text.Json;
+
+namespace Doppler.HtmlEditorApi;
+
+public static class Utils
+{
+    public static JsonElement ParseAsJsonElement(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.Clone();
+    }
+}


### PR DESCRIPTION
Hi team!

In this PR I am preparing the codebase to deal with a new content type.

These changes are introducing a minor breaking change that [we are already ready to deal with in the WebApp](https://github.com/FromDoppler/doppler-editors-webapp/pull/101): After merging this, the field `type` will be included and **also required** in the API payloads.