### PR TITLE
Wrap Dapper

### DIFF
--- a/Doppler.HtmlEditorApi.Test/Doppler.HtmlEditorApi.Test.csproj
+++ b/Doppler.HtmlEditorApi.Test/Doppler.HtmlEditorApi.Test.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.2" />
     <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="ReflectionMagic" Version="4.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Doppler.HtmlEditorApi.Test/GetCampaignTest.cs
+++ b/Doppler.HtmlEditorApi.Test/GetCampaignTest.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using Doppler.HtmlEditorApi.Storage;
 using Doppler.HtmlEditorApi.Storage.DapperProvider;
+using Doppler.HtmlEditorApi.Test.Utils;
 using Doppler.HtmlEditorApi.ApiModels;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
@@ -180,11 +181,13 @@ namespace Doppler.HtmlEditorApi
                 expectedIdCampaign,
                 html);
 
+            dynamic dbParams = null;
+
             var dbContextMock = new Mock<IDbContext>();
             dbContextMock
                 .Setup(x => x.QueryFirstOrDefaultAsync(
                     It.IsAny<string>(),
-                    It.IsAny<object>()))
+                    It.Is<object>(x => AssertHelper.GetDynamicValueAndContinue(x, out dbParams))))
                 .ReturnsAsync((object)new
                 {
                     IdCampaign = expectedIdCampaign,
@@ -215,6 +218,8 @@ namespace Doppler.HtmlEditorApi
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(expectedIdCampaign, dbParams.IdCampaign);
+            Assert.Equal(expectedAccountName, dbParams.accountName);
             Assert.False(responseContentJson.TryGetProperty("meta", out _));
             Assert.Equal("html", responseContentJson.GetProperty("type").GetString());
             Assert.Equal(html, responseContentJson.GetProperty("htmlContent").GetString());

--- a/Doppler.HtmlEditorApi.Test/GetCampaignTest.cs
+++ b/Doppler.HtmlEditorApi.Test/GetCampaignTest.cs
@@ -10,6 +10,7 @@ using Doppler.HtmlEditorApi.ApiModels;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
+using ReflectionMagic;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -184,17 +185,15 @@ namespace Doppler.HtmlEditorApi
                 .Setup(x => x.QueryFirstOrDefaultAsync(
                     It.IsAny<string>(),
                     It.IsAny<object>()))
-                .ReturnsAsync(() => {
-                    // I hate Expandos!
-                    dynamic r = new System.Dynamic.ExpandoObject();
-                    r.IdCampaign = expectedIdCampaign;
-                    r.CampaignBelongsUser = true;
-                    r.CampaignExists = true;
-                    r.CampaignHasContent = true;
-                    r.EditorType = (int?)null;
-                    r.Content = html;
-                    return r;
-                });
+                .ReturnsAsync((object)new
+                {
+                    IdCampaign = expectedIdCampaign,
+                    CampaignBelongsUser = true,
+                    CampaignExists = true,
+                    CampaignHasContent = true,
+                    EditorType = (int?)null,
+                    Content = html
+                }.AsDynamic());
 
             var client = _factory
                 .WithWebHostBuilder(c =>

--- a/Doppler.HtmlEditorApi.Test/Utils/AssertHelper.cs
+++ b/Doppler.HtmlEditorApi.Test/Utils/AssertHelper.cs
@@ -1,0 +1,18 @@
+using ReflectionMagic;
+
+namespace Doppler.HtmlEditorApi.Test.Utils;
+
+public static class AssertHelper
+{
+    public static bool GetValueAndContinue<T>(T input, out T output)
+    {
+        output = input;
+        return true;
+    }
+
+    public static bool GetDynamicValueAndContinue(object input, out dynamic output)
+    {
+        output = input.AsDynamic();
+        return true;
+    }
+}

--- a/Doppler.HtmlEditorApi/Startup.cs
+++ b/Doppler.HtmlEditorApi/Startup.cs
@@ -70,6 +70,7 @@ namespace Doppler.HtmlEditorApi
             });
             services.AddScoped<IRepository, Repository>();
             services.AddScoped<IDatabaseConnectionFactory, DatabaseConnectionFactory>();
+            services.AddScoped<IDbContext, DapperWrapperDbContext>();
             services.Configure<DopplerDatabaseSettings>(Configuration.GetSection(nameof(DopplerDatabaseSettings)));
         }
 

--- a/Doppler.HtmlEditorApi/Startup.cs
+++ b/Doppler.HtmlEditorApi/Startup.cs
@@ -11,8 +11,6 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
 using Hellang.Middleware.ProblemDetails;
-using Doppler.HtmlEditorApi.Storage;
-using Doppler.HtmlEditorApi.Storage.DapperProvider;
 
 namespace Doppler.HtmlEditorApi
 {
@@ -68,10 +66,7 @@ namespace Doppler.HtmlEditorApi
                     c.AddServer(new OpenApiServer() { Url = baseUrl });
                 };
             });
-            services.AddScoped<IRepository, Repository>();
-            services.AddScoped<IDatabaseConnectionFactory, DatabaseConnectionFactory>();
-            services.AddScoped<IDbContext, DapperWrapperDbContext>();
-            services.Configure<DopplerDatabaseSettings>(Configuration.GetSection(nameof(DopplerDatabaseSettings)));
+            services.AddDapperProvider(Configuration);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/Doppler.HtmlEditorApi/Storage.DapperProvider/DapperWrapperDbContext.cs
+++ b/Doppler.HtmlEditorApi/Storage.DapperProvider/DapperWrapperDbContext.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Data;
+using System.Threading.Tasks;
+using Dapper;
+
+namespace Doppler.HtmlEditorApi.Storage.DapperProvider;
+
+public class DapperWrapperDbContext : IDbContext, IDisposable
+{
+    private readonly Lazy<IDbConnection> _lazyDbConnection;
+    private bool disposedValue;
+
+    public DapperWrapperDbContext(IDatabaseConnectionFactory databaseConnectionFactory)
+    {
+        _lazyDbConnection = new Lazy<IDbConnection>(() => databaseConnectionFactory.GetConnection());
+    }
+
+    public Task<dynamic> QueryFirstOrDefaultAsync(string query, object param)
+        => _lazyDbConnection.Value.QueryFirstOrDefaultAsync(query, param);
+
+    public Task<int> ExecuteAsync(string query, object param)
+        => _lazyDbConnection.Value.ExecuteAsync(query, param);
+
+    public void Dispose()
+    {
+        if (!disposedValue && _lazyDbConnection.IsValueCreated)
+        {
+            disposedValue = true;
+            _lazyDbConnection.Value.Dispose();
+        }
+    }
+}

--- a/Doppler.HtmlEditorApi/Storage.DapperProvider/IDbContext.cs
+++ b/Doppler.HtmlEditorApi/Storage.DapperProvider/IDbContext.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Data;
+using System.Threading.Tasks;
+
+namespace Doppler.HtmlEditorApi.Storage.DapperProvider;
+
+public interface IDbContext
+{
+    Task<dynamic> QueryFirstOrDefaultAsync(string query, object param);
+    Task<int> ExecuteAsync(string query, object param);
+}

--- a/Doppler.HtmlEditorApi/Storage.DapperProvider/Repository.cs
+++ b/Doppler.HtmlEditorApi/Storage.DapperProvider/Repository.cs
@@ -12,17 +12,15 @@ public class Repository : IRepository
     private const int EDITOR_TYPE_MSEDITOR = 4;
     private const int EDITOR_TYPE_UNLAYER = 5;
 
-    private readonly IDatabaseConnectionFactory _connectionFactory;
-    public Repository(IDatabaseConnectionFactory connectionFactory)
+    private readonly IDbContext _dbContext;
+    public Repository(IDbContext dbContext)
     {
-        _connectionFactory = connectionFactory;
+        _dbContext = dbContext;
     }
 
     public async Task<ContentData> GetCampaignModel(string accountName, int campaignId)
     {
-        using (var connection = _connectionFactory.GetConnection())
-        {
-            var databaseQuery = @"
+        var databaseQuery = @"
 SELECT
 CAST (CASE WHEN co.IdCampaign IS NULL THEN 0 ELSE 1 END AS BIT) AS CampaignHasContent,
 CAST (CASE WHEN ca.IdUser IS NULL THEN 0 ELSE 1 END AS BIT) AS CampaignBelongsUser,
@@ -34,66 +32,63 @@ AND ca.IdCampaign = @IdCampaign
 LEFT JOIN [Content] co ON ca.IdCampaign = co.IdCampaign
 WHERE u.Email = @accountName";
 
-            // TODO: use a type for the result
-            var queryResult = await connection.QueryFirstOrDefaultAsync<dynamic>(databaseQuery, new { IdCampaign = campaignId, accountName });
+        // TODO: use a type for the result
+        var queryResult = await _dbContext.QueryFirstOrDefaultAsync(databaseQuery, new { IdCampaign = campaignId, accountName });
 
-            // TODO: test these both scenarios
-            // Related tests:
-            // * GET_campaign_should_accept_right_tokens_and_return_404_when_DB_returns_null
-            if (!queryResult.CampaignBelongsUser || !queryResult.CampaignExists)
-            {
-                return null;
-            }
-
-            // TODO: test this scenario
-            // Related tests:
-            // * GET_campaign_should_return_empty_content_as_unlayer_content
-            if (!queryResult.CampaignHasContent)
-            {
-                return new EmptyContentData(campaignId);
-            };
-
-            // TODO: test this scenario
-            if (queryResult.EditorType == EDITOR_TYPE_MSEDITOR)
-            {
-                return new MSEditorContentData(campaignId, queryResult.Content);
-            }
-
-            // TODO: test this scenario
-            // Related tests:
-            // * GET_campaign_should_accept_right_tokens_and_return_unlayer_content
-            if (queryResult.EditorType == EDITOR_TYPE_UNLAYER)
-            {
-                return new UnlayerContentData(
-                    campaignId: queryResult.IdCampaign,
-                    htmlContent: queryResult.Content,
-                    meta: queryResult.Meta);
-            }
-
-            // TODO: test this scenario
-            // Related tests:
-            // * GET_campaign_should_return_html_content
-            if (queryResult.EditorType == null)
-            {
-                return new HtmlContentData(
-                    campaignId: queryResult.IdCampaign,
-                    htmlContent: queryResult.Content);
-            }
-
-            // TODO: test this scenario
-            return new UnknownContentData(
-                campaignId: queryResult.IdCampaign,
-                content: queryResult.Content,
-                meta: queryResult.Meta,
-                editorType: queryResult.EditorType);
+        // TODO: test these both scenarios
+        // Related tests:
+        // * GET_campaign_should_accept_right_tokens_and_return_404_when_DB_returns_null
+        if (!queryResult.CampaignBelongsUser || !queryResult.CampaignExists)
+        {
+            return null;
         }
+
+        // TODO: test this scenario
+        // Related tests:
+        // * GET_campaign_should_return_empty_content_as_unlayer_content
+        if (!queryResult.CampaignHasContent)
+        {
+            return new EmptyContentData(campaignId);
+        };
+
+        // TODO: test this scenario
+        if (queryResult.EditorType == EDITOR_TYPE_MSEDITOR)
+        {
+            return new MSEditorContentData(campaignId, queryResult.Content);
+        }
+
+        // TODO: test this scenario
+        // Related tests:
+        // * GET_campaign_should_accept_right_tokens_and_return_unlayer_content
+        if (queryResult.EditorType == EDITOR_TYPE_UNLAYER)
+        {
+            return new UnlayerContentData(
+                campaignId: queryResult.IdCampaign,
+                htmlContent: queryResult.Content,
+                meta: queryResult.Meta);
+        }
+
+        // TODO: test this scenario
+        // Related tests:
+        // * GET_campaign_should_return_html_content
+        if (queryResult.EditorType == null)
+        {
+            return new HtmlContentData(
+                campaignId: queryResult.IdCampaign,
+                htmlContent: queryResult.Content);
+        }
+
+        // TODO: test this scenario
+        return new UnknownContentData(
+            campaignId: queryResult.IdCampaign,
+            content: queryResult.Content,
+            meta: queryResult.Meta,
+            editorType: queryResult.EditorType);
     }
 
     public async Task SaveCampaignContent(string accountName, ContentData contentRow)
     {
-        using (var connection = _connectionFactory.GetConnection())
-        {
-            var databaseQuery = @"
+        var databaseQuery = @"
 SELECT
 CAST (CASE WHEN ca.IdCampaign IS NULL THEN 0 ELSE 1 END AS BIT) AS OwnCampaignExists,
 CAST (CASE WHEN co.IdCampaign IS NULL THEN 0 ELSE 1 END AS BIT) AS ContentExists,
@@ -104,49 +99,48 @@ AND ca.IdCampaign = @IdCampaign
 LEFT JOIN [Content] co ON ca.IdCampaign = co.IdCampaign
 WHERE u.Email = @accountName
 ";
-            // TODO: use a type for the result
-            var campaignStatus = await connection.QueryFirstOrDefaultAsync<dynamic>(databaseQuery, new { contentRow.campaignId, accountName });
+        // TODO: use a type for the result
+        var campaignStatus = await _dbContext.QueryFirstOrDefaultAsync(databaseQuery, new { contentRow.campaignId, accountName });
 
-            // TODO: consider returning 404 NotFound
-            // TODO: test this scenario
-            if (!campaignStatus.OwnCampaignExists)
-            {
-                throw new ApplicationException($"CampaignId {contentRow.campaignId} does not exists or belongs to another user than {accountName}");
-            }
-
-            // TODO: test these scenarios
-            var query = campaignStatus.ContentExists
-                ? @"UPDATE Content SET Content = @Content, Meta = @Meta, EditorType = @EditorType WHERE IdCampaign = @IdCampaign"
-                : @"INSERT INTO Content (IdCampaign, Content, Meta, EditorType) VALUES (@IdCampaign, @Content, @Meta, @EditorType)";
-
-            var queryParams = contentRow switch
-            {
-                // TODO: test this scenario
-                // Related tests:
-                // * PUT_campaign_should_store_unlayer_content
-                UnlayerContentData unlayerContentData => new
-                {
-                    IdCampaign = unlayerContentData.campaignId,
-                    Content = unlayerContentData.htmlContent,
-                    Meta = unlayerContentData.meta,
-                    EditorType = (int?)EDITOR_TYPE_UNLAYER
-                },
-                // TODO: test this scenario
-                // Related tests:
-                // * PUT_campaign_should_store_html_content
-                HtmlContentData htmlContentData => new
-                {
-                    IdCampaign = htmlContentData.campaignId,
-                    Content = htmlContentData.htmlContent,
-                    Meta = (string)null,
-                    EditorType = (int?)null
-                },
-                // TODO: test this scenario
-                // Probably a unit test will be necessary
-                _ => throw new NotImplementedException($"Unsupported campaign content type {contentRow.GetType()}")
-            };
-
-            await connection.ExecuteAsync(query, queryParams);
+        // TODO: consider returning 404 NotFound
+        // TODO: test this scenario
+        if (!campaignStatus.OwnCampaignExists)
+        {
+            throw new ApplicationException($"CampaignId {contentRow.campaignId} does not exists or belongs to another user than {accountName}");
         }
+
+        // TODO: test these scenarios
+        var query = campaignStatus.ContentExists
+            ? @"UPDATE Content SET Content = @Content, Meta = @Meta, EditorType = @EditorType WHERE IdCampaign = @IdCampaign"
+            : @"INSERT INTO Content (IdCampaign, Content, Meta, EditorType) VALUES (@IdCampaign, @Content, @Meta, @EditorType)";
+
+        var queryParams = contentRow switch
+        {
+            // TODO: test this scenario
+            // Related tests:
+            // * PUT_campaign_should_store_unlayer_content
+            UnlayerContentData unlayerContentData => new
+            {
+                IdCampaign = unlayerContentData.campaignId,
+                Content = unlayerContentData.htmlContent,
+                Meta = unlayerContentData.meta,
+                EditorType = (int?)EDITOR_TYPE_UNLAYER
+            },
+            // TODO: test this scenario
+            // Related tests:
+            // * PUT_campaign_should_store_html_content
+            HtmlContentData htmlContentData => new
+            {
+                IdCampaign = htmlContentData.campaignId,
+                Content = htmlContentData.htmlContent,
+                Meta = (string)null,
+                EditorType = (int?)null
+            },
+            // TODO: test this scenario
+            // Probably a unit test will be necessary
+            _ => throw new NotImplementedException($"Unsupported campaign content type {contentRow.GetType()}")
+        };
+
+        await _dbContext.ExecuteAsync(query, queryParams);
     }
 }

--- a/Doppler.HtmlEditorApi/Storage.DapperProvider/ServiceCollectionExtensions.cs
+++ b/Doppler.HtmlEditorApi/Storage.DapperProvider/ServiceCollectionExtensions.cs
@@ -12,7 +12,7 @@ public static class ServiceCollectionExtensions
     static public IServiceCollection AddDapperProvider(this IServiceCollection services, IConfiguration configuration)
         => services
             .AddScoped<IRepository, Repository>()
-            .AddScoped<IDatabaseConnectionFactory, DatabaseConnectionFactory>()
+            .AddSingleton<IDatabaseConnectionFactory, DatabaseConnectionFactory>()
             .AddScoped<IDbContext, DapperWrapperDbContext>()
             .Configure<DopplerDatabaseSettings>(configuration.GetSection(nameof(DopplerDatabaseSettings)));
 }

--- a/Doppler.HtmlEditorApi/Storage.DapperProvider/ServiceCollectionExtensions.cs
+++ b/Doppler.HtmlEditorApi/Storage.DapperProvider/ServiceCollectionExtensions.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Data;
+using System.Threading.Tasks;
+using Doppler.HtmlEditorApi.Storage;
+using Doppler.HtmlEditorApi.Storage.DapperProvider;
+using Microsoft.Extensions.Configuration;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+public static class ServiceCollectionExtensions
+{
+    static public IServiceCollection AddDapperProvider(this IServiceCollection services, IConfiguration configuration)
+        => services
+            .AddScoped<IRepository, Repository>()
+            .AddScoped<IDatabaseConnectionFactory, DatabaseConnectionFactory>()
+            .AddScoped<IDbContext, DapperWrapperDbContext>()
+            .Configure<DopplerDatabaseSettings>(configuration.GetSection(nameof(DopplerDatabaseSettings)));
+}


### PR DESCRIPTION
Hi team!

In other projects, we are using [Moq.Dapper](https://github.com/UnoSD/Moq.Dapper), but I found it too limited and uncomfortable for the usage.

There is a nice discussion about the topic of testing Dapper: https://github.com/DapperLib/Dapper/issues/1074

I liked the approach of [DataAbstractions.Dapper](https://github.com/codeapologist/DataAbstractions.Dapper), but I think that by the moment, in place of wrapping the IDbConnection, it could be a good idea to add a new abstraction for the _DB context_ with scoped lifetime.

Also, probably we will use only a couple of Dapper methods and I do not like to have all Dapper methods available.

I only migrate one test to the new approach. As you see, mocking dynamic methods is not so nice. So, the next steps are:

* Add types for the queries' parameters and results
* Test the repository in all the integration tests

What do you think?

---

Since there are a lot of changes in indentation, I recommend you to review hiding whitespaces 

![image](https://user-images.githubusercontent.com/1157864/154720209-d2fdc0f9-88cc-48b4-a0aa-adff23e2a9f4.png)
