### PR TITLE
Typed query data

### DIFF
--- a/Doppler.HtmlEditorApi.Test/GetCampaignTest.cs
+++ b/Doppler.HtmlEditorApi.Test/GetCampaignTest.cs
@@ -6,12 +6,11 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using Doppler.HtmlEditorApi.Storage;
 using Doppler.HtmlEditorApi.Storage.DapperProvider;
-using Doppler.HtmlEditorApi.Test.Utils;
+using Doppler.HtmlEditorApi.Storage.DapperProvider.Queries;
 using Doppler.HtmlEditorApi.ApiModels;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
-using ReflectionMagic;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -181,14 +180,14 @@ namespace Doppler.HtmlEditorApi
                 expectedIdCampaign,
                 html);
 
-            dynamic dbParams = null;
-
             var dbContextMock = new Mock<IDbContext>();
             dbContextMock
-                .Setup(x => x.QueryFirstOrDefaultAsync(
+                .Setup(x => x.QueryFirstOrDefaultAsync<FirstOrDefaultContentWithCampaignStatusDbQuery.Result>(
                     It.IsAny<string>(),
-                    It.Is<object>(x => AssertHelper.GetDynamicValueAndContinue(x, out dbParams))))
-                .ReturnsAsync((object)new
+                    It.Is<FirstOrDefaultContentWithCampaignStatusDbQuery.Parameters>(x =>
+                        x.AccountName == expectedAccountName
+                        && x.IdCampaign == expectedIdCampaign)))
+                .ReturnsAsync(new FirstOrDefaultContentWithCampaignStatusDbQuery.Result()
                 {
                     IdCampaign = expectedIdCampaign,
                     CampaignBelongsUser = true,
@@ -196,7 +195,7 @@ namespace Doppler.HtmlEditorApi
                     CampaignHasContent = true,
                     EditorType = (int?)null,
                     Content = html
-                }.AsDynamic());
+                });
 
             var client = _factory
                 .WithWebHostBuilder(c =>
@@ -218,8 +217,6 @@ namespace Doppler.HtmlEditorApi
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            Assert.Equal(expectedIdCampaign, dbParams.IdCampaign);
-            Assert.Equal(expectedAccountName, dbParams.accountName);
             Assert.False(responseContentJson.TryGetProperty("meta", out _));
             Assert.Equal("html", responseContentJson.GetProperty("type").GetString());
             Assert.Equal(html, responseContentJson.GetProperty("htmlContent").GetString());

--- a/Doppler.HtmlEditorApi/Storage.DapperProvider/DapperWrapperDbContext.cs
+++ b/Doppler.HtmlEditorApi/Storage.DapperProvider/DapperWrapperDbContext.cs
@@ -15,6 +15,9 @@ public class DapperWrapperDbContext : IDbContext, IDisposable
         _lazyDbConnection = new Lazy<IDbConnection>(() => databaseConnectionFactory.GetConnection());
     }
 
+    public Task<TResult> QueryFirstOrDefaultAsync<TResult>(string query, object param)
+        => _lazyDbConnection.Value.QueryFirstOrDefaultAsync<TResult>(query, param);
+
     public Task<dynamic> QueryFirstOrDefaultAsync(string query, object param)
         => _lazyDbConnection.Value.QueryFirstOrDefaultAsync(query, param);
 

--- a/Doppler.HtmlEditorApi/Storage.DapperProvider/IDbContext.cs
+++ b/Doppler.HtmlEditorApi/Storage.DapperProvider/IDbContext.cs
@@ -6,6 +6,7 @@ namespace Doppler.HtmlEditorApi.Storage.DapperProvider;
 
 public interface IDbContext
 {
+    Task<TResult> QueryFirstOrDefaultAsync<TResult>(string query, object param);
     Task<dynamic> QueryFirstOrDefaultAsync(string query, object param);
     Task<int> ExecuteAsync(string query, object param);
 }

--- a/Doppler.HtmlEditorApi/Storage.DapperProvider/Queries/DbQuery.cs
+++ b/Doppler.HtmlEditorApi/Storage.DapperProvider/Queries/DbQuery.cs
@@ -1,0 +1,11 @@
+using System.Threading.Tasks;
+
+namespace Doppler.HtmlEditorApi.Storage.DapperProvider.Queries;
+
+public abstract class DbQuery<TParametes, TResult>
+{
+    protected IDbContext DbContext { get; }
+    public DbQuery(IDbContext dbContext) => DbContext = dbContext;
+    abstract protected string SqlQuery { get; }
+    public abstract Task<TResult> ExecuteAsync(TParametes parameters);
+}

--- a/Doppler.HtmlEditorApi/Storage.DapperProvider/Queries/FirstOrDefaultContentWithCampaignStatusDbQuery.cs
+++ b/Doppler.HtmlEditorApi/Storage.DapperProvider/Queries/FirstOrDefaultContentWithCampaignStatusDbQuery.cs
@@ -1,0 +1,21 @@
+namespace Doppler.HtmlEditorApi.Storage.DapperProvider.Queries;
+
+public class FirstOrDefaultContentWithCampaignStatusDbQuery
+{
+    public class Result
+    {
+        public int IdCampaign { get; init; }
+        public bool CampaignHasContent { get; init; }
+        public bool CampaignBelongsUser { get; init; }
+        public bool CampaignExists { get; init; }
+        public int? EditorType { get; init; }
+        public string Content { get; init; }
+        public string Meta { get; init; }
+    }
+
+    public class Parameters
+    {
+        public int IdCampaign { get; init; }
+        public string AccountName { get; init; }
+    }
+}

--- a/Doppler.HtmlEditorApi/Storage.DapperProvider/Repository.cs
+++ b/Doppler.HtmlEditorApi/Storage.DapperProvider/Repository.cs
@@ -7,8 +7,7 @@ namespace Doppler.HtmlEditorApi.Storage.DapperProvider;
 
 public class Repository : IRepository
 {
-    // TODO: add types to represent Dapper queries results.
-    // Because dynamic Dapper results do nowork with Moq.Dapper.
+    // TODO: add types to represent Dapper pending queries results.
 
     private const int EDITOR_TYPE_MSEDITOR = 4;
     private const int EDITOR_TYPE_UNLAYER = 5;
@@ -21,22 +20,8 @@ public class Repository : IRepository
 
     public async Task<ContentData> GetCampaignModel(string accountName, int campaignId)
     {
-        var databaseQuery = @"
-SELECT
-CAST (CASE WHEN co.IdCampaign IS NULL THEN 0 ELSE 1 END AS BIT) AS CampaignHasContent,
-CAST (CASE WHEN ca.IdUser IS NULL THEN 0 ELSE 1 END AS BIT) AS CampaignBelongsUser,
-CAST (CASE WHEN ca.IdCampaign IS NULL THEN 0 ELSE 1 END AS BIT) AS CampaignExists,
-ca.IdCampaign, co.Content, co.EditorType, co.Meta
-FROM [User] u
-LEFT JOIN [Campaign] ca ON u.IdUser = ca.IdUser
-AND ca.IdCampaign = @IdCampaign
-LEFT JOIN [Content] co ON ca.IdCampaign = co.IdCampaign
-WHERE u.Email = @AccountName";
-
-        // TODO: use a type for the result
-        var queryResult = await _dbContext.QueryFirstOrDefaultAsync<FirstOrDefaultContentWithCampaignStatusDbQuery.Result>(
-            databaseQuery,
-            new FirstOrDefaultContentWithCampaignStatusDbQuery.Parameters()
+        var queryResult = await new FirstOrDefaultContentWithCampaignStatusDbQuery(_dbContext)
+            .ExecuteAsync(new()
             {
                 IdCampaign = campaignId,
                 AccountName = accountName

--- a/Doppler.HtmlEditorApi/Storage.DapperProvider/Repository.cs
+++ b/Doppler.HtmlEditorApi/Storage.DapperProvider/Repository.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Dapper;
+using Doppler.HtmlEditorApi.Storage.DapperProvider.Queries;
 
 namespace Doppler.HtmlEditorApi.Storage.DapperProvider;
 
@@ -30,10 +31,16 @@ FROM [User] u
 LEFT JOIN [Campaign] ca ON u.IdUser = ca.IdUser
 AND ca.IdCampaign = @IdCampaign
 LEFT JOIN [Content] co ON ca.IdCampaign = co.IdCampaign
-WHERE u.Email = @accountName";
+WHERE u.Email = @AccountName";
 
         // TODO: use a type for the result
-        var queryResult = await _dbContext.QueryFirstOrDefaultAsync(databaseQuery, new { IdCampaign = campaignId, accountName });
+        var queryResult = await _dbContext.QueryFirstOrDefaultAsync<FirstOrDefaultContentWithCampaignStatusDbQuery.Result>(
+            databaseQuery,
+            new FirstOrDefaultContentWithCampaignStatusDbQuery.Parameters()
+            {
+                IdCampaign = campaignId,
+                AccountName = accountName
+            });
 
         // TODO: test these both scenarios
         // Related tests:


### PR DESCRIPTION
Hi team!

This PR updates one of our queries to be type-safe.

Encapsulating the extension method, the query, the parameters type, and the result type in a static class could look weird. But in my opinion, it is a way to keep together the things that are changed together.

What do you think?

---

It is pending to apply this same approach to the other queries and update the tests to take advantage of this.