### PR TITLE
DE-460 - Campaign step

### DIFF
--- a/Doppler.HtmlEditorApi.Test/SaveCampaignTest.cs
+++ b/Doppler.HtmlEditorApi.Test/SaveCampaignTest.cs
@@ -366,7 +366,7 @@ namespace Doppler.HtmlEditorApi
         [InlineData(4, true, "UPDATE")]
         [InlineData(5, true, "UPDATE")]
         [InlineData(null, false, "INSERT")]
-        public async Task PUT_campaign_should_store_html_content(int? currentEditorType, bool contentExists, string sqlQueryStartsWith)
+        public async Task PUT_campaign_should_store_html_content_and_ensure_campaign_status(int? currentEditorType, bool contentExists, string sqlQueryStartsWith)
         {
             // Arrange
             var url = "/accounts/test1@test.com/campaigns/123/content";
@@ -396,6 +396,16 @@ namespace Doppler.HtmlEditorApi
                         c.IdCampaign == expectedIdCampaign
                         && c.Content == htmlContent
                         && c.Meta == null)))
+                .ReturnsAsync(1);
+
+            dbContextMock
+                .Setup(x => x.ExecuteAsync(
+                    It.Is<string>(s => s.Trim().StartsWith("UPDATE Campaign")),
+                    It.Is<UpdateCampaignStatusDbQuery.Parameters>(c =>
+                        c.setCurrentStep == 2
+                        && c.setHtmlSourceType == 2
+                        && c.whenCurrentStepIs == 1
+                        && c.whenIdCampaignIs == expectedIdCampaign)))
                 .ReturnsAsync(1);
 
             var client = _factory
@@ -430,7 +440,7 @@ namespace Doppler.HtmlEditorApi
         [InlineData(4, true, "UPDATE")]
         [InlineData(5, true, "UPDATE")]
         [InlineData(null, false, "INSERT")]
-        public async Task PUT_campaign_should_store_unlayer_content(int? currentEditorType, bool contentExists, string sqlQueryStartsWith)
+        public async Task PUT_campaign_should_store_unlayer_content_and_ensure_campaign_status(int? currentEditorType, bool contentExists, string sqlQueryStartsWith)
         {
             // Arrange
             var url = "/accounts/test1@test.com/campaigns/123/content";
@@ -461,6 +471,16 @@ namespace Doppler.HtmlEditorApi
                         c.IdCampaign == expectedIdCampaign
                         && c.Content == htmlContent
                         && c.Meta == metaAsString)))
+                .ReturnsAsync(1);
+
+            dbContextMock
+                .Setup(x => x.ExecuteAsync(
+                    It.Is<string>(s => s.Trim().StartsWith("UPDATE Campaign")),
+                    It.Is<UpdateCampaignStatusDbQuery.Parameters>(c =>
+                        c.setCurrentStep == 2
+                        && c.setHtmlSourceType == 2
+                        && c.whenCurrentStepIs == 1
+                        && c.whenIdCampaignIs == expectedIdCampaign)))
                 .ReturnsAsync(1);
 
             var client = _factory

--- a/Doppler.HtmlEditorApi/Storage.DapperProvider/Queries/UpdateCampaignStatusDbQuery.cs
+++ b/Doppler.HtmlEditorApi/Storage.DapperProvider/Queries/UpdateCampaignStatusDbQuery.cs
@@ -1,0 +1,31 @@
+using System.Threading.Tasks;
+
+namespace Doppler.HtmlEditorApi.Storage.DapperProvider.Queries;
+
+public class UpdateCampaignStatusDbQuery : DbQuery<UpdateCampaignStatusDbQuery.Parameters, int>
+{
+    // See https://github.com/MakingSense/Doppler/blob/48cf637bb1f8b4d81837fff904d8736fe889ff1c/Doppler.Transversal/Classes/CampaignHTMLContentTypeEnum.cs#L12-L17
+    // We are using Template because Editor seems to be tied to the old HTML Editor
+    public const int TEMPLATE_HTML_SOURCE_TYPE = 2;
+
+    public UpdateCampaignStatusDbQuery(IDbContext dbContext) : base(dbContext) { }
+
+    protected override string SqlQuery => @"
+UPDATE Campaign
+SET
+    CurrentStep = @setCurrentStep,
+    HtmlSourceType = @setHtmlSourceType
+WHERE
+    IdCampaign = @whenIdCampaignIs
+    AND CurrentStep = @whenCurrentStepIs";
+
+    public override Task<int> ExecuteAsync(UpdateCampaignStatusDbQuery.Parameters parameters)
+        => DbContext.ExecuteAsync(SqlQuery, parameters);
+
+    public record Parameters(
+        int setCurrentStep,
+        int? setHtmlSourceType,
+        int whenIdCampaignIs,
+        int whenCurrentStepIs
+    );
+}

--- a/Doppler.HtmlEditorApi/Storage.DapperProvider/Repository.cs
+++ b/Doppler.HtmlEditorApi/Storage.DapperProvider/Repository.cs
@@ -77,7 +77,7 @@ public class Repository : IRepository
             throw new ApplicationException($"CampaignId {contentRow.campaignId} does not exists or belongs to another user than {accountName}");
         }
 
-        DbQuery<ContentRow, int> query = campaignStatus.ContentExists
+        DbQuery<ContentRow, int> upsertContentQuery = campaignStatus.ContentExists
             ? new UpdateCampaignContentDbQuery(_dbContext)
             : new InsertCampaignContentDbQuery(_dbContext);
 
@@ -102,6 +102,6 @@ public class Repository : IRepository
             _ => throw new NotImplementedException($"Unsupported campaign content type {contentRow.GetType()}")
         };
 
-        await query.ExecuteAsync(queryParams);
+        await upsertContentQuery.ExecuteAsync(queryParams);
     }
 }

--- a/Doppler.HtmlEditorApi/Storage.DapperProvider/Repository.cs
+++ b/Doppler.HtmlEditorApi/Storage.DapperProvider/Repository.cs
@@ -103,5 +103,13 @@ public class Repository : IRepository
         };
 
         await upsertContentQuery.ExecuteAsync(queryParams);
+
+        var updateCampaignStatusQuery = new UpdateCampaignStatusDbQuery(_dbContext);
+
+        await updateCampaignStatusQuery.ExecuteAsync(new UpdateCampaignStatusDbQuery.Parameters(
+            setCurrentStep: 2,
+            setHtmlSourceType: UpdateCampaignStatusDbQuery.TEMPLATE_HTML_SOURCE_TYPE,
+            whenIdCampaignIs: contentRow.campaignId,
+            whenCurrentStepIs: 1));
     }
 }


### PR DESCRIPTION
Hi team!

We have two entities: the campaign and the content.

Previously, we tough that Doppler would understand that the campaign has content if it exists. So, as we have an idempotent API, we simply inserted or updated the content: https://github.com/FromDoppler/doppler-html-editor-api/blob/a2c2805a73dc912cbb064d5eb5aefd17372abfc3/Doppler.HtmlEditorApi/Storage.DapperProvider/Repository.cs#L80-L82

But Doppler did not understand that: 

![image](https://user-images.githubusercontent.com/1157864/155520647-b226f729-8854-4edb-8270-5d2a478aae47.png)

Besides to create the content, we need to increment the `CurrentStep` from `1` to `2` and set [`HtmlSourceType`](https://github.com/MakingSense/Doppler/blob/48cf637bb1f8b4d81837fff904d8736fe889ff1c/Doppler.Transversal/Classes/CampaignHTMLContentTypeEnum.cs#L12-L17).

After these changes, I tested it and now it is working as expected:

<img width="1157" alt="image" src="https://user-images.githubusercontent.com/1157864/155719230-a23cf778-584c-474e-9840-459cd79b88c5.png">
