### PR TITLE
DE-474 - Split body and head (alternative implementation)

### DIFF
--- a/Doppler.HtmlEditorApi.Test/GetCampaignTest.cs
+++ b/Doppler.HtmlEditorApi.Test/GetCampaignTest.cs
@@ -132,6 +132,7 @@ namespace Doppler.HtmlEditorApi
                     schemaVersion = expectedSchemaVersion
                 }),
                 htmlContent: "<html></html>",
+                htmlHead: null,
                 campaignId: expectedIdCampaign);
 
             var repositoryMock = new Mock<IRepository>();

--- a/Doppler.HtmlEditorApi.Test/HtmlContentProcessingIntegrationTests.cs
+++ b/Doppler.HtmlEditorApi.Test/HtmlContentProcessingIntegrationTests.cs
@@ -1,0 +1,123 @@
+using Doppler.HtmlEditorApi.Storage.DapperProvider.Queries;
+using Doppler.HtmlEditorApi.Storage.DapperProvider;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Net;
+using System.Threading.Tasks;
+using Doppler.HtmlEditorApi.Test.Utils;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit.Abstractions;
+using Xunit;
+
+namespace Doppler.HtmlEditorApi;
+
+public class HtmlContentProcessingIntegrationTests
+    : IClassFixture<WebApplicationFactory<Startup>>
+{
+    const string TOKEN_ACCOUNT_123_TEST1_AT_TEST_DOT_COM_EXPIRE_20330518 = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1laWQiOjEyMywidW5pcXVlX25hbWUiOiJ0ZXN0MUB0ZXN0LmNvbSIsInJvbGUiOiJVU0VSIiwiZXhwIjoyMDAwMDAwMDAwfQ.E3RHjKx9p0a-64RN2YPtlEMysGM45QBO9eATLBhtP4tUQNZnkraUr56hAWA-FuGmhiuMptnKNk_dU3VnbyL6SbHrMWUbquxWjyoqsd7stFs1K_nW6XIzsTjh8Bg6hB5hmsSV-M5_hPS24JwJaCdMQeWrh6cIEp2Sjft7I1V4HQrgzrkMh15sDFAw3i1_ZZasQsDYKyYbO9Jp7lx42ognPrz_KuvPzLjEXvBBNTFsVXUE-ur5adLNMvt-uXzcJ1rcwhjHWItUf5YvgRQbbBnd9f-LsJIhfkDgCJcvZmGDZrtlCKaU1UjHv5c3faZED-cjL59MbibofhPjv87MK8hhdg";
+    const string TOKEN_EXPIRE_20330518 = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjIwMDAwMDAwMDB9.mll33c0kstVIN9Moo4HSw0CwRjn0IuDc2h1wkRrv2ahQtIG1KV5KIxYw-H3oRfd-PiCWHhIVIYDP3mWDZbsOHTlnpRGpHp4f26LAu1Xp1hDJfOfxKYEGEE62Xt_0qp7jSGQjrx-vQey4l2mNcWkOWiE0plOws7cX-wLUvA3NLPoOvEegjM0Wx6JFcvYLdMGcTGT5tPd8Pq8pe9VYstCbhOClzI0bp81iON3f7VQP5d0n64eb_lvEPFu5OfURD4yZK2htyQK7agcNNkP1c5mLEfUi39C7Qtx96aAhOjir6Wfhzv_UEs2GQKXGTHl6_-HH-ecgOdIvvbqXGLeDmTkXUQ";
+    const string TOKEN_SUPERUSER_EXPIRE_20010908 = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc1NVIjp0cnVlLCJleHAiOjEwMDAwMDAwMDB9.FYOpOxrXSHDif3lbQLPEStMllzEktWPKQ2T4vKUq5qgVjiH_ki0W0Ansvt0PMlaLHqq7OOL9XGFebtgUcyU6aXPO9cZuq6Od196TWDLMdnxZ-Ct0NxWxulyMbjTglUiI3V6g3htcM5EaurGvfu66kbNDuHO-WIQRYFfJtbm7EuOP7vYBZ26hf5Vk5KvGtCWha4zRM55i1-CKMhXvhPN_lypn6JLENzJGYHkBC9Cx2DwzaT683NWtXiVzeMJq3ohC6jvRpkezv89QRes2xUW4fRgvgRGQvaeQ4huNW_TwQKTTikH2Jg7iHbuRqqwYuPZiWuRkjqfd8_80EdlSAnO94Q";
+    const string TOKEN_ACCOUNT_123_TEST1_AT_TEST_DOT_COM_EXPIRE_20010908 = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1laWQiOjEyMywidW5pcXVlX25hbWUiOiJ0ZXN0MUB0ZXN0LmNvbSIsInJvbGUiOiJVU0VSIiwiZXhwIjoxMDAwMDAwMDAwfQ.JBmiZBgKVSUtB4_NhD1kiUhBTnH2ufGSzcoCwC3-Gtx0QDvkFjy2KbxIU9asscenSdzziTOZN6IfFx6KgZ3_a3YB7vdCgfSINQwrAK0_6Owa-BQuNAIsKk-pNoIhJ-OcckV-zrp5wWai3Ak5Qzg3aZ1NKZQKZt5ICZmsFZcWu_4pzS-xsGPcj5gSr3Iybt61iBnetrkrEbjtVZg-3xzKr0nmMMqe-qqeknozIFy2YWAObmTkrN4sZ3AB_jzqyFPXN-nMw3a0NxIdJyetbESAOcNnPLymBKZEZmX2psKuXwJxxekvgK9egkfv2EjKYF9atpH5XwC0Pd4EWvraLAL2eg";
+    const string TOKEN_SUPERUSER_EXPIRE_20330518 = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc1NVIjp0cnVlLCJleHAiOjIwMDAwMDAwMDB9.rUtvRqMxrnQzVHDuAjgWa2GJAJwZ-wpaxqdjwP7gmVa7XJ1pEmvdTMBdirKL5BJIE7j2_hsMvEOKUKVjWUY-IE0e0u7c82TH0l_4zsIztRyHMKtt9QE9rBRQnJf8dcT5PnLiWkV_qEkpiIKQ-wcMZ1m7vQJ0auEPZyyFBKmU2caxkZZOZ8Kw_1dx-7lGUdOsUYad-1Rt-iuETGAFijQrWggcm3kV_KmVe8utznshv2bAdLJWydbsAUEfNof0kZK5Wu9A80DJd3CRiNk8mWjQxF_qPOrGCANOIYofhB13yuYi48_8zVPYku-llDQjF77BmQIIIMrCXs8IMT3Lksdxuw";
+
+    #region Content examples
+    const string BODY_CONTENT = "<div>Hello body!</div>";
+    const string ORPHAN_DIV_CONTENT = "<div>Hello orphan div!</div>";
+    const string HTML_WITHOUT_HEAD = $@"<!doctype html>
+<html>
+<body>
+{BODY_CONTENT}
+</body>
+</html>";
+    const string HTML_WITHOUT_HEAD_WITH_ORPHAN_DIV = $@"<!doctype html>
+<html>
+{ORPHAN_DIV_CONTENT}
+</html>";
+    #endregion Content examples
+
+    private readonly WebApplicationFactory<Startup> _factory;
+    private readonly ITestOutputHelper _output;
+
+    public HtmlContentProcessingIntegrationTests(WebApplicationFactory<Startup> factory, ITestOutputHelper output)
+    {
+        _factory = factory;
+        _output = output;
+    }
+
+    [Theory]
+    [InlineData(ORPHAN_DIV_CONTENT, null, ORPHAN_DIV_CONTENT, "html", true)]
+    [InlineData(ORPHAN_DIV_CONTENT, null, ORPHAN_DIV_CONTENT, "html", false)]
+    [InlineData(ORPHAN_DIV_CONTENT, null, ORPHAN_DIV_CONTENT, "unlayer", true)]
+    [InlineData(HTML_WITHOUT_HEAD, null, HTML_WITHOUT_HEAD, "html", true)]
+    [InlineData(HTML_WITHOUT_HEAD, null, HTML_WITHOUT_HEAD, "html", false)]
+    [InlineData(HTML_WITHOUT_HEAD, null, HTML_WITHOUT_HEAD, "unlayer", true)]
+    [InlineData(HTML_WITHOUT_HEAD_WITH_ORPHAN_DIV, null, HTML_WITHOUT_HEAD_WITH_ORPHAN_DIV, "html", true)]
+    [InlineData(HTML_WITHOUT_HEAD_WITH_ORPHAN_DIV, null, HTML_WITHOUT_HEAD_WITH_ORPHAN_DIV, "html", false)]
+    [InlineData(HTML_WITHOUT_HEAD_WITH_ORPHAN_DIV, null, HTML_WITHOUT_HEAD_WITH_ORPHAN_DIV, "unlayer", true)]
+    public async Task PUT_campaign_should_split_html_in_head_and_content(string htmlInput, string expectedHead, string expectedContent, string type, bool existingContent)
+    {
+        // Arrange
+        var url = "/accounts/test1@test.com/campaigns/123/content";
+        var token = TOKEN_ACCOUNT_123_TEST1_AT_TEST_DOT_COM_EXPIRE_20330518;
+        var accountName = "test1@test.com";
+        var idCampaign = 123;
+
+        var dbContextMock = new Mock<IDbContext>();
+        dbContextMock
+            .Setup(x => x.QueryFirstOrDefaultAsync<FirstOrDefaultCampaignStatusDbQuery.Result>(
+                It.IsAny<string>(),
+                It.Is<ByCampaignIdAndAccountNameParameters>(x =>
+                    x.AccountName == accountName
+                    && x.IdCampaign == idCampaign)))
+            .ReturnsAsync(new FirstOrDefaultCampaignStatusDbQuery.Result()
+            {
+                OwnCampaignExists = true,
+                ContentExists = existingContent,
+                EditorType = null,
+            });
+
+        dbContextMock
+            .Setup(x => x.ExecuteAsync(
+                It.IsAny<string>(),
+                It.IsAny<ContentRow>()))
+            .ReturnsAsync(1);
+
+        var client = _factory
+            .WithWebHostBuilder(c =>
+            {
+                c.ConfigureServices(s =>
+                {
+                    s.AddSingleton(dbContextMock.Object);
+                });
+            })
+            .CreateClient(new WebApplicationFactoryClientOptions());
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        // Act
+        var response = await client.PutAsync(url, JsonContent.Create(new
+        {
+            type = type,
+            htmlContent = htmlInput,
+            meta = "true" // it does not care
+        }));
+
+        _output.WriteLine(response.GetHeadersAsString());
+        var responseContent = await response.Content.ReadAsStringAsync();
+        _output.WriteLine(responseContent);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        dbContextMock.VerifyAll();
+
+        ContentRow contentRow = null;
+        dbContextMock.Verify(x => x.ExecuteAsync(
+            It.IsAny<string>(),
+            It.Is<ContentRow>(x => AssertHelper.GetValueAndContinue(x, out contentRow))));
+
+        Assert.Equal(idCampaign, contentRow.IdCampaign);
+        Assert.Equal(expectedContent, contentRow.Content);
+        Assert.Equal(expectedHead, contentRow.Head);
+    }
+}

--- a/Doppler.HtmlEditorApi.Test/Utils/AssertHelper.cs
+++ b/Doppler.HtmlEditorApi.Test/Utils/AssertHelper.cs
@@ -1,9 +1,14 @@
+using System.Text.RegularExpressions;
 using ReflectionMagic;
+using Xunit;
 
 namespace Doppler.HtmlEditorApi.Test.Utils;
 
 public static class AssertHelper
 {
+    private static readonly Regex LINE_ENDINGS_REGEX = new Regex(@"[\r\n]");
+    private static readonly Regex SPACES_REGEX = new Regex(@"\s");
+
     public static bool GetValueAndContinue<T>(T input, out T output)
     {
         output = input;
@@ -15,4 +20,13 @@ public static class AssertHelper
         output = input.AsDynamic();
         return true;
     }
+
+    public static void EqualIgnoringSpaces(string expected, string actual)
+        => Assert.Equal(RemoveSpaces(expected), RemoveSpaces(actual));
+
+    public static string RemoveSpaces(string str)
+        => str == null ? null
+        : SPACES_REGEX.Replace(
+            LINE_ENDINGS_REGEX.Replace(str, string.Empty),
+            string.Empty);
 }

--- a/Doppler.HtmlEditorApi/Doppler.HtmlEditorApi.csproj
+++ b/Doppler.HtmlEditorApi/Doppler.HtmlEditorApi.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Serilog.Sinks.Loggly" Version="5.4.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.42" />
   </ItemGroup>
 
 </Project>

--- a/Doppler.HtmlEditorApi/DopplerHtmlParser.cs
+++ b/Doppler.HtmlEditorApi/DopplerHtmlParser.cs
@@ -1,3 +1,5 @@
+using HtmlAgilityPack;
+
 namespace Doppler.HtmlEditorApi;
 
 /// <summary>
@@ -10,15 +12,26 @@ public class DopplerHtmlParser
     // Old Doppler code:
     // https://github.com/MakingSense/Doppler/blob/ed24e901c990b7fb2eaeaed557c62c1adfa80215/Doppler.HypermediaAPI/ApiMappers/ToDoppler/CampaignContent_To_DtoContent.cs#L27-L29
     private readonly string _inputHtml;
+    private readonly HtmlDocument _htmlDocument;
+    private readonly HtmlNode _headNode;
 
     public DopplerHtmlParser(string inputHtml)
     {
         _inputHtml = inputHtml;
+        _htmlDocument = new HtmlDocument();
+        _htmlDocument.LoadHtml(inputHtml);
+        _headNode = _htmlDocument.DocumentNode.SelectSingleNode("//head");
     }
 
     public string GetDopplerContent()
-        => _inputHtml;
+        => EnsureContent(
+            _headNode == null ? _inputHtml
+                : _htmlDocument.DocumentNode.SelectSingleNode("//body")?.InnerHtml
+                ?? _inputHtml.Replace(_headNode.OuterHtml, ""));
 
     public string GetHeadContent()
-        => null;
+        => _headNode?.InnerHtml;
+
+    private static string EnsureContent(string htmlContent)
+        => string.IsNullOrWhiteSpace(htmlContent) ? "<BR>" : htmlContent;
 }

--- a/Doppler.HtmlEditorApi/DopplerHtmlParser.cs
+++ b/Doppler.HtmlEditorApi/DopplerHtmlParser.cs
@@ -1,0 +1,24 @@
+namespace Doppler.HtmlEditorApi;
+
+/// <summary>
+/// This class deals with the conversion between a standard HTML content
+/// and the set of strings that represents the content in Doppler DB.
+/// It is named Doppler because it should replicate current Doppler logic.
+/// </summary>
+public class DopplerHtmlParser
+{
+    // Old Doppler code:
+    // https://github.com/MakingSense/Doppler/blob/ed24e901c990b7fb2eaeaed557c62c1adfa80215/Doppler.HypermediaAPI/ApiMappers/ToDoppler/CampaignContent_To_DtoContent.cs#L27-L29
+    private readonly string _inputHtml;
+
+    public DopplerHtmlParser(string inputHtml)
+    {
+        _inputHtml = inputHtml;
+    }
+
+    public string GetDopplerContent()
+        => _inputHtml;
+
+    public string GetHeadContent()
+        => null;
+}

--- a/Doppler.HtmlEditorApi/Storage.DapperProvider/Queries/ContentRow.cs
+++ b/Doppler.HtmlEditorApi/Storage.DapperProvider/Queries/ContentRow.cs
@@ -7,5 +7,6 @@ public class ContentRow
     public int IdCampaign { get; init; }
     public int? EditorType { get; init; }
     public string Content { get; init; }
+    public string Head { get; init; }
     public string Meta { get; init; }
 }

--- a/Doppler.HtmlEditorApi/Storage.DapperProvider/Queries/FirstOrDefaultContentWithCampaignStatusDbQuery.cs
+++ b/Doppler.HtmlEditorApi/Storage.DapperProvider/Queries/FirstOrDefaultContentWithCampaignStatusDbQuery.cs
@@ -13,6 +13,7 @@ SELECT
     CAST (CASE WHEN co.IdCampaign IS NULL THEN 0 ELSE 1 END AS BIT) AS CampaignHasContent,
     co.EditorType,
     co.Content,
+    co.Head,
     co.Meta
 FROM [User] u
 LEFT JOIN [Campaign] ca ON
@@ -33,6 +34,7 @@ WHERE
         public bool CampaignHasContent { get; init; }
         public int? EditorType { get; init; }
         public string Content { get; init; }
+        public string Head { get; init; }
         public string Meta { get; init; }
     }
 }

--- a/Doppler.HtmlEditorApi/Storage.DapperProvider/Queries/InsertCampaignContentDbQuery.cs
+++ b/Doppler.HtmlEditorApi/Storage.DapperProvider/Queries/InsertCampaignContentDbQuery.cs
@@ -11,11 +11,13 @@ public class InsertCampaignContentDbQuery : DbQuery<ContentRow, int>
 INSERT INTO Content (
     IdCampaign,
     Content,
+    Head,
     Meta,
     EditorType
 ) VALUES (
     @IdCampaign,
     @Content,
+    @Head,
     @Meta,
     @EditorType
 )";

--- a/Doppler.HtmlEditorApi/Storage.DapperProvider/Queries/UpdateCampaignContentDbQuery.cs
+++ b/Doppler.HtmlEditorApi/Storage.DapperProvider/Queries/UpdateCampaignContentDbQuery.cs
@@ -11,6 +11,7 @@ public class UpdateCampaignContentDbQuery : DbQuery<ContentRow, int>
 UPDATE Content
 SET
     Content = @Content,
+    Head = @Head,
     Meta = @Meta,
     EditorType = @EditorType
 WHERE IdCampaign = @IdCampaign";

--- a/Doppler.HtmlEditorApi/Storage.DapperProvider/Repository.cs
+++ b/Doppler.HtmlEditorApi/Storage.DapperProvider/Repository.cs
@@ -45,6 +45,7 @@ public class Repository : IRepository
             return new UnlayerContentData(
                 campaignId: queryResult.IdCampaign,
                 htmlContent: queryResult.Content,
+                htmlHead: queryResult.Head,
                 meta: queryResult.Meta);
         }
 
@@ -52,12 +53,14 @@ public class Repository : IRepository
         {
             return new HtmlContentData(
                 campaignId: queryResult.IdCampaign,
-                htmlContent: queryResult.Content);
+                htmlContent: queryResult.Content,
+                htmlHead: queryResult.Head);
         }
 
         return new UnknownContentData(
             campaignId: queryResult.IdCampaign,
             content: queryResult.Content,
+            head: queryResult.Head,
             meta: queryResult.Meta,
             editorType: queryResult.EditorType);
     }
@@ -87,6 +90,7 @@ public class Repository : IRepository
             {
                 IdCampaign = unlayerContentData.campaignId,
                 Content = unlayerContentData.htmlContent,
+                Head = unlayerContentData.htmlHead,
                 Meta = unlayerContentData.meta,
                 EditorType = (int?)EDITOR_TYPE_UNLAYER
             },
@@ -94,6 +98,7 @@ public class Repository : IRepository
             {
                 IdCampaign = htmlContentData.campaignId,
                 Content = htmlContentData.htmlContent,
+                Head = htmlContentData.htmlHead,
                 Meta = (string)null,
                 EditorType = (int?)null
             },

--- a/Doppler.HtmlEditorApi/Storage.DummyProvider/DummyRepository.cs
+++ b/Doppler.HtmlEditorApi/Storage.DummyProvider/DummyRepository.cs
@@ -63,6 +63,7 @@ public class DummyRepository : IRepository
         ContentData contentRow = new UnlayerContentData(
             campaignId: campaignId,
             htmlContent: "<html></html>",
+            htmlHead: null,
             meta: JsonSerializer.Serialize(_demoMeta));
 
         return Task.FromResult(contentRow);

--- a/Doppler.HtmlEditorApi/Storage/ContentData.cs
+++ b/Doppler.HtmlEditorApi/Storage/ContentData.cs
@@ -10,6 +10,7 @@ public sealed record EmptyContentData(
 public sealed record UnknownContentData(
     int campaignId,
     string content,
+    string head,
     string meta,
     int? editorType)
     : ContentData(campaignId);
@@ -21,16 +22,19 @@ public sealed record MSEditorContentData(
 
 public abstract record BaseHtmlContentData(
     int campaignId,
-    string htmlContent)
+    string htmlContent,
+    string htmlHead)
     : ContentData(campaignId);
 
 public sealed record HtmlContentData(
     int campaignId,
-    string htmlContent)
-    : BaseHtmlContentData(campaignId, htmlContent);
+    string htmlContent,
+    string htmlHead)
+    : BaseHtmlContentData(campaignId, htmlContent, htmlHead);
 
 public sealed record UnlayerContentData(
     int campaignId,
     string htmlContent,
+    string htmlHead,
     string meta)
-    : BaseHtmlContentData(campaignId, htmlContent);
+    : BaseHtmlContentData(campaignId, htmlContent, htmlHead);


### PR DESCRIPTION
It is an alternative to #51

> I am following almost the same Doppler behavior to split head and body parts of the HTML content.
> 
> Notice that the behavior to write and read the content is not symmetric. So. when you read the HTML you will lose information as it happens with Doppler.
> 
> At this moment, it does not affect us because the Drag-n-drop Unlayer Editor does not use the HTML content, and the Classic Unlayer HTML Editor ignores the head. It could only affect us if we want to edit imported content with the Classic Unlayer HTML Editor.

I like this implementation because it is less procedural than #51. In my opinion, it is part of the core of the domain logic of this API and probably we will never replace _HtmlAgilityPack_ with another thing. It is also simpler and allows us to continue with this simple approach for other things.

CC: @ms-darianbenito 