### PR TITLE
DE-472 - Convert field name tags to field id tags on saving content (step 1)

### DIFF
--- a/Doppler.HtmlEditorApi.Test/HtmlContentProcessingIntegrationTests.cs
+++ b/Doppler.HtmlEditorApi.Test/HtmlContentProcessingIntegrationTests.cs
@@ -167,6 +167,8 @@ public class HtmlContentProcessingIntegrationTests
     [Theory]
     [InlineData("unlayer", "<div>Hola |*|319*|* |*|98765*|*, tenemos una oferta para vos</div>", "<div>Hola  |*|319*|* , tenemos una oferta para vos</div>")]
     [InlineData("html", "<div>Hola |*|319*|* |*|98765*|*, tenemos una oferta para vos</div>", "<div>Hola  |*|319*|* , tenemos una oferta para vos</div>")]
+    [InlineData("unlayer", "<div>Hola [[[FIRST_NAME]]] [[[UNKNOWN_FIELD]]], tenemos una oferta para vos</div>", "<div>Hola  |*|319*|* [[[UNKNOWN_FIELD]]], tenemos una oferta para vos</div>")]
+    [InlineData("html", "<div>Hola [[[first_name]]] [[[UNKNOWN_FIELD]]], tenemos una oferta para vos</div>", "<div>Hola  |*|319*|* [[[UNKNOWN_FIELD]]], tenemos una oferta para vos</div>")]
     public async Task PUT_campaign_should_remove_unknown_fieldIds(string type, string htmlInput, string expectedContent)
     {
         // Arrange

--- a/Doppler.HtmlEditorApi.Test/HtmlContentProcessingIntegrationTests.cs
+++ b/Doppler.HtmlEditorApi.Test/HtmlContentProcessingIntegrationTests.cs
@@ -169,6 +169,9 @@ public class HtmlContentProcessingIntegrationTests
     [InlineData("html", "<div>Hola |*|319*|* |*|98765*|*, tenemos una oferta para vos</div>", "<div>Hola  |*|319*|* , tenemos una oferta para vos</div>")]
     [InlineData("unlayer", "<div>Hola [[[FIRST_NAME]]] [[[UNKNOWN_FIELD]]], tenemos una oferta para vos</div>", "<div>Hola  |*|319*|* [[[UNKNOWN_FIELD]]], tenemos una oferta para vos</div>")]
     [InlineData("html", "<div>Hola [[[first_name]]] [[[UNKNOWN_FIELD]]], tenemos una oferta para vos</div>", "<div>Hola  |*|319*|* [[[UNKNOWN_FIELD]]], tenemos una oferta para vos</div>")]
+    [InlineData("unlayer", "<div>Hola [[[nombre]]] [[[UNKNOWN_FIELD]]], tenemos una oferta para vos</div>", "<div>Hola  |*|319*|* [[[UNKNOWN_FIELD]]], tenemos una oferta para vos</div>")]
+    [InlineData("unlayer", "<div>Hola [[[first name]]] [[[UNKNOWN_FIELD]]], tenemos una oferta para vos</div>", "<div>Hola  |*|319*|* [[[UNKNOWN_FIELD]]], tenemos una oferta para vos</div>")]
+    [InlineData("html", "Hoy ([[[cumpleaños]]]) es tu cumpleaños", "Hoy (|*|323*|*) es tu cumpleaños")]
     public async Task PUT_campaign_should_remove_unknown_fieldIds(string type, string htmlInput, string expectedContent)
     {
         // Arrange

--- a/Doppler.HtmlEditorApi.Test/HtmlContentProcessingIntegrationTests.cs
+++ b/Doppler.HtmlEditorApi.Test/HtmlContentProcessingIntegrationTests.cs
@@ -165,6 +165,69 @@ public class HtmlContentProcessingIntegrationTests
     }
 
     [Theory]
+    [InlineData("unlayer", "<div>Hola |*|319*|* |*|98765*|*, tenemos una oferta para vos</div>", "<div>Hola  |*|319*|* , tenemos una oferta para vos</div>")]
+    [InlineData("html", "<div>Hola |*|319*|* |*|98765*|*, tenemos una oferta para vos</div>", "<div>Hola  |*|319*|* , tenemos una oferta para vos</div>")]
+    public async Task PUT_campaign_should_remove_unknown_fieldIds(string type, string htmlInput, string expectedContent)
+    {
+        // Arrange
+        var url = "/accounts/test1@test.com/campaigns/123/content";
+        var token = TOKEN_ACCOUNT_123_TEST1_AT_TEST_DOT_COM_EXPIRE_20330518;
+        var idCampaign = 123;
+
+        var dbContextMock = new Mock<IDbContext>();
+        dbContextMock
+            .Setup(x => x.QueryFirstOrDefaultAsync<FirstOrDefaultCampaignStatusDbQuery.Result>(
+                It.IsAny<string>(),
+                It.IsAny<ByCampaignIdAndAccountNameParameters>()))
+            .ReturnsAsync(new FirstOrDefaultCampaignStatusDbQuery.Result()
+            {
+                OwnCampaignExists = true,
+                ContentExists = true,
+                EditorType = null,
+            });
+
+        dbContextMock
+            .Setup(x => x.ExecuteAsync(
+                It.IsAny<string>(),
+                It.IsAny<ContentRow>()))
+            .ReturnsAsync(1);
+
+        var client = _factory
+            .WithWebHostBuilder(c =>
+            {
+                c.ConfigureServices(s =>
+                {
+                    s.AddSingleton(dbContextMock.Object);
+                });
+            })
+            .CreateClient(new WebApplicationFactoryClientOptions());
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        // Act
+        var response = await client.PutAsync(url, JsonContent.Create(new
+        {
+            type = type,
+            htmlContent = htmlInput,
+            meta = "true" // it does not care
+        }));
+
+        _output.WriteLine(response.GetHeadersAsString());
+        var responseContent = await response.Content.ReadAsStringAsync();
+        _output.WriteLine(responseContent);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        ContentRow contentRow = null;
+        dbContextMock.Verify(x => x.ExecuteAsync(
+            It.IsAny<string>(),
+            It.Is<ContentRow>(x => AssertHelper.GetValueAndContinue(x, out contentRow))));
+
+        Assert.Equal(idCampaign, contentRow.IdCampaign);
+        AssertHelper.EqualIgnoringSpaces(expectedContent, contentRow.Content);
+    }
+
+    [Theory]
     [InlineData(BODY_CONTENT, HEAD_CONTENT, BODY_CONTENT, null, null)]
     [InlineData(BODY_CONTENT, HEAD_CONTENT, BODY_CONTENT, META_CONTENT, 5)]
     [InlineData(ORPHAN_DIV_CONTENT, null, ORPHAN_DIV_CONTENT, null, null)]

--- a/Doppler.HtmlEditorApi/Controllers/CampaignsController.cs
+++ b/Doppler.HtmlEditorApi/Controllers/CampaignsController.cs
@@ -64,9 +64,9 @@ namespace Doppler.HtmlEditorApi.Controllers
         [HttpPut("/accounts/{accountName}/campaigns/{campaignId}/content")]
         public async Task<IActionResult> SaveCampaign(string accountName, int campaignId, CampaignContent campaignContent)
         {
-            var htmlParser = new DopplerHtmlParser(campaignContent.htmlContent);
-            var head = htmlParser.GetHeadContent();
-            var content = htmlParser.GetDopplerContent();
+            var htmlDocument = new DopplerHtmlDocument(campaignContent.htmlContent);
+            var head = htmlDocument.GetHeadContent();
+            var content = htmlDocument.GetDopplerContent();
 
             BaseHtmlContentData contentRow = campaignContent.type switch
             {

--- a/Doppler.HtmlEditorApi/Controllers/CampaignsController.cs
+++ b/Doppler.HtmlEditorApi/Controllers/CampaignsController.cs
@@ -64,7 +64,12 @@ namespace Doppler.HtmlEditorApi.Controllers
         [HttpPut("/accounts/{accountName}/campaigns/{campaignId}/content")]
         public async Task<IActionResult> SaveCampaign(string accountName, int campaignId, CampaignContent campaignContent)
         {
+            var dopplerFieldsProcessor = new DopplerFieldsProcessor();
+
             var htmlDocument = new DopplerHtmlDocument(campaignContent.htmlContent);
+            htmlDocument.ReplaceFieldNameTagsByFieldIdTags(dopplerFieldsProcessor.GetFieldIdOrNull);
+            htmlDocument.RemoveUnknownFieldIdTags(dopplerFieldsProcessor.FieldIdExist);
+
             var head = htmlDocument.GetHeadContent();
             var content = htmlDocument.GetDopplerContent();
 

--- a/Doppler.HtmlEditorApi/Controllers/CampaignsController.cs
+++ b/Doppler.HtmlEditorApi/Controllers/CampaignsController.cs
@@ -64,7 +64,22 @@ namespace Doppler.HtmlEditorApi.Controllers
         [HttpPut("/accounts/{accountName}/campaigns/{campaignId}/content")]
         public async Task<IActionResult> SaveCampaign(string accountName, int campaignId, CampaignContent campaignContent)
         {
-            var dopplerFieldsProcessor = new DopplerFieldsProcessor();
+            // TODO: get this information from a repository
+            var fields = new[]
+            {
+                new Field(319, "FIRST_NAME", true),
+                new Field(320, "LAST_NAME", true),
+                new Field(321, "EMAIL", true),
+                new Field(322, "GENDER", true),
+                new Field(323, "BIRTHDAY", true),
+                new Field(324, "COUNTRY", true),
+                new Field(325, "CONSENT", true),
+                new Field(326, "ORIGIN", true),
+                new Field(327, "SCORE", true),
+                new Field(106667, "GDPR", true),
+            };
+
+            var dopplerFieldsProcessor = new DopplerFieldsProcessor(fields);
 
             var htmlDocument = new DopplerHtmlDocument(campaignContent.htmlContent);
             htmlDocument.ReplaceFieldNameTagsByFieldIdTags(dopplerFieldsProcessor.GetFieldIdOrNull);

--- a/Doppler.HtmlEditorApi/Controllers/CampaignsController.cs
+++ b/Doppler.HtmlEditorApi/Controllers/CampaignsController.cs
@@ -64,6 +64,17 @@ namespace Doppler.HtmlEditorApi.Controllers
         [HttpPut("/accounts/{accountName}/campaigns/{campaignId}/content")]
         public async Task<IActionResult> SaveCampaign(string accountName, int campaignId, CampaignContent campaignContent)
         {
+            // TODO: get this information from the configuration
+            var fieldAliases = new[]
+            {
+                new FieldAliasesDef("BIRTHDAY", new[] { "CUMPLEANOS", "CUMPLEAÑOS", "DATE OF BIRTH", "DOB", "FECHA DE NACIMIENTO", "NACIMIENTO" }),
+                new FieldAliasesDef("COUNTRY", new[] { "PAIS", "PAÍS" }),
+                new FieldAliasesDef("EMAIL", new[] { "CORREO", "CORREO ELECTRONICO", "CORREO ELECTRÓNICO", "CORREO_ELECTRONICO", "CORREO_ELECTRÓNICO", "E-MAIL", "MAIL" }),
+                new FieldAliasesDef("FIRST_NAME", new[] { "FIRST NAME", "FIRST-NAME", "FIRSTNAME", "NAME", "NOMBRE" }),
+                new FieldAliasesDef("GENDER", new[] { "GENERO", "GÉNERO", "SEXO" }),
+                new FieldAliasesDef("LAST_NAME", new[] { "LAST NAME", "LAST-NAME", "LASTNAME", "SURNAME", "APELLIDO" }),
+            };
+
             // TODO: get this information from a repository
             var fields = new[]
             {
@@ -79,7 +90,7 @@ namespace Doppler.HtmlEditorApi.Controllers
                 new Field(106667, "GDPR", true),
             };
 
-            var dopplerFieldsProcessor = new DopplerFieldsProcessor(fields);
+            var dopplerFieldsProcessor = new DopplerFieldsProcessor(fields, fieldAliases);
 
             var htmlDocument = new DopplerHtmlDocument(campaignContent.htmlContent);
             htmlDocument.ReplaceFieldNameTagsByFieldIdTags(dopplerFieldsProcessor.GetFieldIdOrNull);

--- a/Doppler.HtmlEditorApi/DopplerFieldsProcessor.cs
+++ b/Doppler.HtmlEditorApi/DopplerFieldsProcessor.cs
@@ -15,11 +15,9 @@ public class DopplerFieldsProcessor
 
     private readonly ReadOnlyDictionary<int, string> _fieldNamesById;
 
-    public DopplerFieldsProcessor(IEnumerable<Field> fields)
+    public DopplerFieldsProcessor(IEnumerable<Field> fields, IEnumerable<FieldAliasesDef> aliasesByCanonical)
     {
-        // TODO: support field aliases
-        _fieldIdsByNameOrAlias = new ReadOnlyDictionary<string, int>(
-            fields.ToDictionary(x => x.name, x => x.id, StringComparer.OrdinalIgnoreCase));
+        _fieldIdsByNameOrAlias = CreateDictionaryOfIdsByNameOrAlias(fields, aliasesByCanonical);
 
         // Only canonical names
         _fieldNamesById = new ReadOnlyDictionary<int, string>(
@@ -33,4 +31,21 @@ public class DopplerFieldsProcessor
 
     public bool FieldIdExist(int fieldId)
         => _fieldNamesById.ContainsKey(fieldId);
+
+    private static ReadOnlyDictionary<string, int> CreateDictionaryOfIdsByNameOrAlias(IEnumerable<Field> fields, IEnumerable<FieldAliasesDef> aliasesByCanonical)
+    {
+        var fieldIdsByNameOrAlias = fields.ToDictionary(x => x.name, x => x.id, StringComparer.OrdinalIgnoreCase);
+
+        var idsAndAlias = aliasesByCanonical
+            .SelectMany(x => x.aliases.Select(alias => new { x.canonicalName, alias }))
+            .Where(x => fieldIdsByNameOrAlias.ContainsKey(x.canonicalName))
+            .Select(x => new { id = fieldIdsByNameOrAlias[x.canonicalName], x.alias });
+
+        foreach (var pair in idsAndAlias)
+        {
+            fieldIdsByNameOrAlias.TryAdd(pair.alias, pair.id);
+        }
+
+        return new ReadOnlyDictionary<string, int>(fieldIdsByNameOrAlias);
+    }
 }

--- a/Doppler.HtmlEditorApi/DopplerFieldsProcessor.cs
+++ b/Doppler.HtmlEditorApi/DopplerFieldsProcessor.cs
@@ -1,0 +1,21 @@
+namespace Doppler.HtmlEditorApi;
+
+/// <summary>
+/// This class deals with the conversion between Doppler field-names
+/// to Doppler field-ids and vice versa.
+/// </summary>
+public class DopplerFieldsProcessor
+{
+    public DopplerFieldsProcessor()
+    {
+        // TODO: receive and prepare fields information
+    }
+
+    public int? GetFieldIdOrNull(string fieldName)
+        // TODO: complete the behavior here
+        => null;
+
+    public bool FieldIdExist(int fieldId)
+        // TODO: complete the behavior here
+        => true;
+}

--- a/Doppler.HtmlEditorApi/DopplerFieldsProcessor.cs
+++ b/Doppler.HtmlEditorApi/DopplerFieldsProcessor.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -10,11 +11,15 @@ namespace Doppler.HtmlEditorApi;
 /// </summary>
 public class DopplerFieldsProcessor
 {
+    private readonly ReadOnlyDictionary<string, int> _fieldIdsByNameOrAlias;
+
     private readonly ReadOnlyDictionary<int, string> _fieldNamesById;
 
     public DopplerFieldsProcessor(IEnumerable<Field> fields)
     {
-        // TODO: receive and prepare fields information
+        // TODO: support field aliases
+        _fieldIdsByNameOrAlias = new ReadOnlyDictionary<string, int>(
+            fields.ToDictionary(x => x.name, x => x.id, StringComparer.OrdinalIgnoreCase));
 
         // Only canonical names
         _fieldNamesById = new ReadOnlyDictionary<int, string>(
@@ -22,8 +27,9 @@ public class DopplerFieldsProcessor
     }
 
     public int? GetFieldIdOrNull(string fieldName)
-        // TODO: complete the behavior here
-        => null;
+        => _fieldIdsByNameOrAlias.TryGetValue(fieldName, out var fieldId)
+            ? fieldId
+            : null;
 
     public bool FieldIdExist(int fieldId)
         => _fieldNamesById.ContainsKey(fieldId);

--- a/Doppler.HtmlEditorApi/DopplerFieldsProcessor.cs
+++ b/Doppler.HtmlEditorApi/DopplerFieldsProcessor.cs
@@ -1,3 +1,7 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
 namespace Doppler.HtmlEditorApi;
 
 /// <summary>
@@ -6,9 +10,15 @@ namespace Doppler.HtmlEditorApi;
 /// </summary>
 public class DopplerFieldsProcessor
 {
-    public DopplerFieldsProcessor()
+    private readonly ReadOnlyDictionary<int, string> _fieldNamesById;
+
+    public DopplerFieldsProcessor(IEnumerable<Field> fields)
     {
         // TODO: receive and prepare fields information
+
+        // Only canonical names
+        _fieldNamesById = new ReadOnlyDictionary<int, string>(
+            fields.ToDictionary(x => x.id, x => x.name));
     }
 
     public int? GetFieldIdOrNull(string fieldName)
@@ -16,6 +26,5 @@ public class DopplerFieldsProcessor
         => null;
 
     public bool FieldIdExist(int fieldId)
-        // TODO: complete the behavior here
-        => true;
+        => _fieldNamesById.ContainsKey(fieldId);
 }

--- a/Doppler.HtmlEditorApi/DopplerHtmlDocument.cs
+++ b/Doppler.HtmlEditorApi/DopplerHtmlDocument.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Text.RegularExpressions;
 using HtmlAgilityPack;
 
 namespace Doppler.HtmlEditorApi;
@@ -11,6 +13,24 @@ public class DopplerHtmlDocument
 {
     // Old Doppler code:
     // https://github.com/MakingSense/Doppler/blob/ed24e901c990b7fb2eaeaed557c62c1adfa80215/Doppler.HypermediaAPI/ApiMappers/ToDoppler/CampaignContent_To_DtoContent.cs#L27-L29
+
+    // TODO: consider remove the linebreaks in hrefs:
+    // * https://github.com/MakingSense/Doppler/blob/ed24e901c990b7fb2eaeaed557c62c1adfa80215/Doppler.Domain.Core/Classes/Utils.cs#L147-L151
+    // TODO: consider sanitize field names
+    // Searching the canonical name in FieldsRes.resx (replacing " " and "%20" by "_" in the key)
+    // * https://github.com/MakingSense/Doppler/blob/e0bf2aa982ac8b9902430395fd293fdcd3c231a8/Doppler.Application.CampaignsModule/Services/Classes/CampaignContentService.cs#L3428
+    // * https://github.com/MakingSense/Doppler/blob/e0bf2aa982ac8b9902430395fd293fdcd3c231a8/Doppler.Application.ListsModule/Utils/FieldHelper.cs#L65-L81
+    // * https://github.com/MakingSense/Doppler/blob/e0bf2aa982ac8b9902430395fd293fdcd3c231a8/Doppler.Application.ListsModule/Utils/FieldHelper.cs#L113-L134
+    // * https://github.com/MakingSense/Doppler/blob/develop/Doppler.Recursos/FieldsRes.resx
+
+    private const string FIELD_NAME_TAG_START_DELIMITER = "[[[";
+    private const string FIELD_NAME_TAG_END_DELIMITER = "]]]";
+    private const string FIELD_ID_TAG_START_DELIMITER = "|*|";
+    private const string FIELD_ID_TAG_END_DELIMITER = "*|*";
+    // % is here to accept %20
+    private static readonly Regex FIELD_NAME_TAG_REGEX = new Regex($@"{Regex.Escape(FIELD_NAME_TAG_START_DELIMITER)}([a-zA-Z0-9 \-_ñÑáéíóúÁÉÍÓÚ%]+){Regex.Escape(FIELD_NAME_TAG_END_DELIMITER)}");
+    private static readonly Regex FIELD_ID_TAG_REGEX = new Regex($@"{Regex.Escape(FIELD_ID_TAG_START_DELIMITER)}(\d+){Regex.Escape(FIELD_ID_TAG_END_DELIMITER)}");
+
     private readonly HtmlNode _headNode;
     private readonly HtmlNode _contentNode;
 
@@ -30,6 +50,36 @@ public class DopplerHtmlDocument
 
     public string GetHeadContent()
         => _headNode?.InnerHtml;
+
+    public void ReplaceFieldNameTagsByFieldIdTags(Func<string, int?> getFieldIdOrNullFunc)
+    {
+        // TODO: optimize it to do many replacements while traversing the HTML document
+        _contentNode.InnerHtml = FIELD_NAME_TAG_REGEX.Replace(
+            _contentNode.InnerHtml,
+            // TODO: take into account %20 and that kind of things
+            match =>
+            {
+                var fieldName = match.Groups[1].Value;
+                var fieldId = getFieldIdOrNullFunc(fieldName);
+                return fieldId.HasValue
+                    ? CreateFieldIdTag(fieldId.GetValueOrDefault())
+                    // keep the name when field doesn't exist
+                    : match.Value;
+            });
+    }
+
+    public void RemoveUnknownFieldIdTags(Func<int, bool> fieldIdExistFunc)
+    {
+        // TODO: optimize it to do many replacements while traversing the HTML document
+        _contentNode.InnerHtml = FIELD_ID_TAG_REGEX.Replace(
+            _contentNode.InnerHtml,
+            match => fieldIdExistFunc(int.Parse(match.Groups[1].ValueSpan))
+                ? match.Value
+                : string.Empty);
+    }
+
+    private static string CreateFieldIdTag(int? fieldId)
+        => $"{FIELD_ID_TAG_START_DELIMITER}{fieldId}{FIELD_ID_TAG_END_DELIMITER}";
 
     private static string EnsureContent(string htmlContent)
         => string.IsNullOrWhiteSpace(htmlContent) ? "<BR>" : htmlContent;

--- a/Doppler.HtmlEditorApi/DopplerHtmlDocument.cs
+++ b/Doppler.HtmlEditorApi/DopplerHtmlDocument.cs
@@ -7,31 +7,37 @@ namespace Doppler.HtmlEditorApi;
 /// and the set of strings that represents the content in Doppler DB.
 /// It is named Doppler because it should replicate current Doppler logic.
 /// </summary>
-public class DopplerHtmlParser
+public class DopplerHtmlDocument
 {
     // Old Doppler code:
     // https://github.com/MakingSense/Doppler/blob/ed24e901c990b7fb2eaeaed557c62c1adfa80215/Doppler.HypermediaAPI/ApiMappers/ToDoppler/CampaignContent_To_DtoContent.cs#L27-L29
-    private readonly string _inputHtml;
-    private readonly HtmlDocument _htmlDocument;
     private readonly HtmlNode _headNode;
+    private readonly HtmlNode _contentNode;
 
-    public DopplerHtmlParser(string inputHtml)
+    public DopplerHtmlDocument(string inputHtml)
     {
-        _inputHtml = inputHtml;
-        _htmlDocument = new HtmlDocument();
-        _htmlDocument.LoadHtml(inputHtml);
-        _headNode = _htmlDocument.DocumentNode.SelectSingleNode("//head");
+        var htmlDocument = LoadHtml(inputHtml);
+
+        _headNode = htmlDocument.DocumentNode.SelectSingleNode("//head");
+
+        _contentNode = _headNode == null ? htmlDocument.DocumentNode
+            : htmlDocument.DocumentNode.SelectSingleNode("//body")
+            ?? LoadHtml(inputHtml.Replace(_headNode.OuterHtml, string.Empty)).DocumentNode;
     }
 
     public string GetDopplerContent()
-        => EnsureContent(
-            _headNode == null ? _inputHtml
-                : _htmlDocument.DocumentNode.SelectSingleNode("//body")?.InnerHtml
-                ?? _inputHtml.Replace(_headNode.OuterHtml, ""));
+        => EnsureContent(_contentNode.InnerHtml);
 
     public string GetHeadContent()
         => _headNode?.InnerHtml;
 
     private static string EnsureContent(string htmlContent)
         => string.IsNullOrWhiteSpace(htmlContent) ? "<BR>" : htmlContent;
+
+    private static HtmlDocument LoadHtml(string inputHtml)
+    {
+        var htmlDocument = new HtmlDocument();
+        htmlDocument.LoadHtml(inputHtml);
+        return htmlDocument;
+    }
 }

--- a/Doppler.HtmlEditorApi/Field.cs
+++ b/Doppler.HtmlEditorApi/Field.cs
@@ -1,0 +1,6 @@
+namespace Doppler.HtmlEditorApi;
+
+public record Field(
+    int id,
+    string name,
+    bool isBasic);

--- a/Doppler.HtmlEditorApi/FieldAliasesDef.cs
+++ b/Doppler.HtmlEditorApi/FieldAliasesDef.cs
@@ -1,0 +1,5 @@
+namespace Doppler.HtmlEditorApi;
+
+public record FieldAliasesDef(
+    string canonicalName,
+    params string[] aliases);


### PR DESCRIPTION
Hi team!

Thanks to the help of @mmosquera, @ms-darianbenito, @Cromeror, and @maurocardinali, I think that I found a nice set of abstractions to do this work and the following one (deal with links, restore field name tags on load, etc).

I have renamed the class `DopplerHtmlParser` by `DopplerHtmlDocument`. It is responsible for dealing with the low-level details preparing the HTML content.

And the new class `DopplerFieldsProcessor` is responsible for the translations between field names and filed ids. It does not know anything about HTML or tag delimiters (`[[[`, `|*|`, etc).

I am not using interfaces nor injecting them as dependencies, see a [related discussion in Slack](https://makingsense.slack.com/archives/C1KJY4K6V/p1646223318888339).

There is more work to do here:

- [DE-498](https://makingsense.atlassian.net/browse/DE-498) Read fields from the database (adding a fields repository to create field objects)
- [DE-499](https://makingsense.atlassian.net/browse/DE-499) Read field aliases from the configuration
- [DE-500](https://makingsense.atlassian.net/browse/DE-500) Traversing HTML to make the field replacements only in text elements and attribute values in an optimal way

But I think that is a good starting point if you want to continue with the other related tasks.

