### PR TITLE
DE-500 - Traversing HTML to transform field tags

### DIFF
--- a/Doppler.HtmlEditorApi.Test/HtmlContentProcessingIntegrationTests.cs
+++ b/Doppler.HtmlEditorApi.Test/HtmlContentProcessingIntegrationTests.cs
@@ -172,6 +172,10 @@ public class HtmlContentProcessingIntegrationTests
     [InlineData("unlayer", "<div>Hola [[[nombre]]] [[[UNKNOWN_FIELD]]], tenemos una oferta para vos</div>", "<div>Hola  |*|319*|* [[[UNKNOWN_FIELD]]], tenemos una oferta para vos</div>")]
     [InlineData("unlayer", "<div>Hola [[[first name]]] [[[UNKNOWN_FIELD]]], tenemos una oferta para vos</div>", "<div>Hola  |*|319*|* [[[UNKNOWN_FIELD]]], tenemos una oferta para vos</div>")]
     [InlineData("html", "Hoy ([[[cumpleaños]]]) es tu cumpleaños", "Hoy (|*|323*|*) es tu cumpleaños")]
+    [InlineData(
+        "unlayer",
+        "<p>Hola <b><a href=\"https://www.google.com/search?q=[[[first name]]]|*|12345678*|*\">[[[first name]]]</a> [[[cumpleaños]]]</b></p>",
+        "<p>Hola <b><a href=\"https://www.google.com/search?q=|*|319*|*\">|*|319*|*</a> |*|323*|*</b></p>")]
     public async Task PUT_campaign_should_remove_unknown_fieldIds(string type, string htmlInput, string expectedContent)
     {
         // Arrange

--- a/Doppler.HtmlEditorApi.Test/HtmlContentProcessingIntegrationTests.cs
+++ b/Doppler.HtmlEditorApi.Test/HtmlContentProcessingIntegrationTests.cs
@@ -176,6 +176,10 @@ public class HtmlContentProcessingIntegrationTests
         "unlayer",
         "<p>Hola <b><a href=\"https://www.google.com/search?q=[[[first name]]]|*|12345678*|*\">[[[first name]]]</a> [[[cumpleaños]]]</b></p>",
         "<p>Hola <b><a href=\"https://www.google.com/search?q=|*|319*|*\">|*|319*|*</a> |*|323*|*</b></p>")]
+    [InlineData(
+        "unlayer",
+        "<p>Hola <b><a href=\"https://www.google.com/search?q=[[[first%20name]]]%20[[[cumplea&#241;os]]]\">[[[first%20name]]]</a> [[[cumplea&ntilde;os]]]</b></p>",
+        "<p>Hola <b><a href=\"https://www.google.com/search?q=|*|319*|*%20|*|323*|*\">|*|319*|*</a> |*|323*|*</b></p>")]
     public async Task PUT_campaign_should_remove_unknown_fieldIds(string type, string htmlInput, string expectedContent)
     {
         // Arrange

--- a/Doppler.HtmlEditorApi/DopplerHtmlDocument.cs
+++ b/Doppler.HtmlEditorApi/DopplerHtmlDocument.cs
@@ -36,13 +36,13 @@ public class DopplerHtmlDocument
 
     public DopplerHtmlDocument(string inputHtml)
     {
-        var htmlDocument = LoadHtml(inputHtml);
+        var htmlDocument = HtmlAgilityPackUtils.LoadHtml(inputHtml);
 
         _headNode = htmlDocument.DocumentNode.SelectSingleNode("//head");
 
         _contentNode = _headNode == null ? htmlDocument.DocumentNode
             : htmlDocument.DocumentNode.SelectSingleNode("//body")
-            ?? LoadHtml(inputHtml.Replace(_headNode.OuterHtml, string.Empty)).DocumentNode;
+            ?? HtmlAgilityPackUtils.LoadHtml(inputHtml.Replace(_headNode.OuterHtml, string.Empty)).DocumentNode;
     }
 
     public string GetDopplerContent()
@@ -84,10 +84,4 @@ public class DopplerHtmlDocument
     private static string EnsureContent(string htmlContent)
         => string.IsNullOrWhiteSpace(htmlContent) ? "<BR>" : htmlContent;
 
-    private static HtmlDocument LoadHtml(string inputHtml)
-    {
-        var htmlDocument = new HtmlDocument();
-        htmlDocument.LoadHtml(inputHtml);
-        return htmlDocument;
-    }
 }

--- a/Doppler.HtmlEditorApi/DopplerHtmlDocument.cs
+++ b/Doppler.HtmlEditorApi/DopplerHtmlDocument.cs
@@ -53,10 +53,8 @@ public class DopplerHtmlDocument
 
     public void ReplaceFieldNameTagsByFieldIdTags(Func<string, int?> getFieldIdOrNullFunc)
     {
-        // TODO: optimize it to do many replacements while traversing the HTML document
-        _contentNode.InnerHtml = FIELD_NAME_TAG_REGEX.Replace(
-            _contentNode.InnerHtml,
-            // TODO: take into account %20 and that kind of things
+        _contentNode.TraverseAndReplaceTextsAndAttributeValues(text => FIELD_NAME_TAG_REGEX.Replace(
+            text,
             match =>
             {
                 var fieldName = match.Groups[1].Value;
@@ -65,17 +63,16 @@ public class DopplerHtmlDocument
                     ? CreateFieldIdTag(fieldId.GetValueOrDefault())
                     // keep the name when field doesn't exist
                     : match.Value;
-            });
+            }));
     }
 
     public void RemoveUnknownFieldIdTags(Func<int, bool> fieldIdExistFunc)
     {
-        // TODO: optimize it to do many replacements while traversing the HTML document
-        _contentNode.InnerHtml = FIELD_ID_TAG_REGEX.Replace(
-            _contentNode.InnerHtml,
+        _contentNode.TraverseAndReplaceTextsAndAttributeValues(text => FIELD_ID_TAG_REGEX.Replace(
+            text,
             match => fieldIdExistFunc(int.Parse(match.Groups[1].ValueSpan))
                 ? match.Value
-                : string.Empty);
+                : string.Empty));
     }
 
     private static string CreateFieldIdTag(int? fieldId)

--- a/Doppler.HtmlEditorApi/DopplerHtmlDocument.cs
+++ b/Doppler.HtmlEditorApi/DopplerHtmlDocument.cs
@@ -27,8 +27,8 @@ public class DopplerHtmlDocument
     private const string FIELD_NAME_TAG_END_DELIMITER = "]]]";
     private const string FIELD_ID_TAG_START_DELIMITER = "|*|";
     private const string FIELD_ID_TAG_END_DELIMITER = "*|*";
-    // % is here to accept %20
-    private static readonly Regex FIELD_NAME_TAG_REGEX = new Regex($@"{Regex.Escape(FIELD_NAME_TAG_START_DELIMITER)}([a-zA-Z0-9 \-_ñÑáéíóúÁÉÍÓÚ%]+){Regex.Escape(FIELD_NAME_TAG_END_DELIMITER)}");
+    // &, # and ; are here to accept HTML Entities
+    private static readonly Regex FIELD_NAME_TAG_REGEX = new Regex($@"{Regex.Escape(FIELD_NAME_TAG_START_DELIMITER)}([a-zA-Z0-9 \-_ñÑáéíóúÁÉÍÓÚ%&;#]+){Regex.Escape(FIELD_NAME_TAG_END_DELIMITER)}");
     private static readonly Regex FIELD_ID_TAG_REGEX = new Regex($@"{Regex.Escape(FIELD_ID_TAG_START_DELIMITER)}(\d+){Regex.Escape(FIELD_ID_TAG_END_DELIMITER)}");
 
     private readonly HtmlNode _headNode;
@@ -57,7 +57,7 @@ public class DopplerHtmlDocument
             text,
             match =>
             {
-                var fieldName = match.Groups[1].Value;
+                var fieldName = HtmlEntity.DeEntitize(match.Groups[1].Value.Replace("%20", " "));
                 var fieldId = getFieldIdOrNullFunc(fieldName);
                 return fieldId.HasValue
                     ? CreateFieldIdTag(fieldId.GetValueOrDefault())

--- a/Doppler.HtmlEditorApi/HtmlAgilityPack/HtmlAgilityPackUtils.cs
+++ b/Doppler.HtmlEditorApi/HtmlAgilityPack/HtmlAgilityPackUtils.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace HtmlAgilityPack;
+
+public static class HtmlAgilityPackUtils
+{
+    public static HtmlDocument LoadHtml(string inputHtml)
+    {
+        var htmlDocument = new HtmlDocument();
+        htmlDocument.LoadHtml(inputHtml);
+        return htmlDocument;
+    }
+}

--- a/Doppler.HtmlEditorApi/HtmlAgilityPack/HtmlAgilityPackUtils.cs
+++ b/Doppler.HtmlEditorApi/HtmlAgilityPack/HtmlAgilityPackUtils.cs
@@ -4,6 +4,56 @@ namespace HtmlAgilityPack;
 
 public static class HtmlAgilityPackUtils
 {
+    public static void TraverseAndReplaceTextsAndAttributeValues(this HtmlNode node, Func<string, string> replaceFunc)
+    {
+        if (node is HtmlTextNode textNode)
+        {
+            textNode.ReplaceText(replaceFunc);
+        }
+
+        foreach (var attribute in node.Attributes)
+        {
+            attribute.ReplaceValue(replaceFunc);
+        }
+
+        foreach (var child in node.ChildNodes)
+        {
+            child.TraverseAndReplaceTextsAndAttributeValues(replaceFunc);
+        }
+    }
+
+    public static void ReplaceValue(this HtmlAttribute attribute, Func<string, string> replaceFunc)
+    {
+        var originalText = attribute.Value;
+
+        if (originalText == null)
+        {
+            return;
+        }
+
+        var newText = replaceFunc(originalText);
+        if (originalText != newText)
+        {
+            attribute.Value = newText;
+        }
+    }
+
+    public static void ReplaceText(this HtmlTextNode textNode, Func<string, string> replaceFunc)
+    {
+        var originalText = textNode.InnerHtml;
+
+        if (originalText == null)
+        {
+            return;
+        }
+
+        var newText = replaceFunc(originalText);
+        if (originalText != newText)
+        {
+            textNode.InnerHtml = newText;
+        }
+    }
+
     public static HtmlDocument LoadHtml(string inputHtml)
     {
         var htmlDocument = new HtmlDocument();


### PR DESCRIPTION
Hi team!

It is a continuation of #55.

I am replacing the field name tags making honor of HTML structure. I understand that the behavior could change, but I think that it is safer and more extensible.

I am accepting `%20` as space in field names. Doppler was already doing it, probably because some user has an issue with his HTML editor tool.

I am also accepting HTML Entities in the field names, for example in `[[[cumpleaños]]]`. Doppler was not doing it, but I think that it is a reasonable improvement in order to make it robust.

Could you review?

