### PR TITLE
DE-476 - Trackable links sanitization

### DIFF
--- a/Doppler.HtmlEditorApi.Test/DopplerHtmlDocumentTest.cs
+++ b/Doppler.HtmlEditorApi.Test/DopplerHtmlDocumentTest.cs
@@ -72,6 +72,10 @@ public class DopplerHtmlDocumentTest
         "https://\tgoo gle1\n.com    \r\n  ",
         "https://google1.com"
     )]
+    [InlineData(
+        "HTTPS://GOOGLE.com/   SEGMENT",
+        "https://google.com/SEGMENT"
+    )]
     public void SanitizeTrackableLinks_should_sanitize_trackable_links(string inputHref, string expectedHref)
     {
         // Arrange

--- a/Doppler.HtmlEditorApi.Test/DopplerHtmlDocumentTest.cs
+++ b/Doppler.HtmlEditorApi.Test/DopplerHtmlDocumentTest.cs
@@ -66,4 +66,32 @@ public class DopplerHtmlDocumentTest
         // Assert
         Assert.Equal(contentWithoutSanitization, output);
     }
+
+    [Theory]
+    [InlineData(
+        "https://\tgoo gle1\n.com    \r\n  ",
+        "https://google1.com"
+    )]
+    public void SanitizeTrackableLinks_should_sanitize_trackable_links(string inputHref, string expectedHref)
+    {
+        // Arrange
+        var input = CreateTestContentWithLink(inputHref);
+        var expected = CreateTestContentWithLink(expectedHref);
+
+        var htmlDocument = new DopplerHtmlDocument(input);
+
+        // Act
+        htmlDocument.SanitizeTrackableLinks();
+        var output = htmlDocument.GetDopplerContent();
+
+        // Assert
+        Assert.Equal(expected, output);
+    }
+
+    private string CreateTestContentWithLink(string href)
+        => $@"<div>
+    <a href=""{href}"">Link</a>
+</div>
+";
+
 }

--- a/Doppler.HtmlEditorApi.Test/DopplerHtmlDocumentTest.cs
+++ b/Doppler.HtmlEditorApi.Test/DopplerHtmlDocumentTest.cs
@@ -88,6 +88,18 @@ public class DopplerHtmlDocumentTest
         "%20\n%20  HTTP://GOOGLE4.com/TEST%20space%20\n %20  ",
         "http://google4.com/TEST%20space"
     )]
+    [InlineData(
+        "%20\n%20  www.google5.com%20\n %20  ",
+        "http://www.google5.com"
+    )]
+    [InlineData(
+        "%20\n%20  google6.com%20\n %20  ",
+        "%20\n%20  google6.com%20\n %20  "
+    )]
+    [InlineData(
+        "%20\n%20  WWW.GOOGLE7.com/TEST%20space%20\n %20  ",
+        "http://www.google7.com/TEST%20space"
+    )]
     public void SanitizeTrackableLinks_should_sanitize_trackable_links(string inputHref, string expectedHref)
     {
         // Arrange

--- a/Doppler.HtmlEditorApi.Test/DopplerHtmlDocumentTest.cs
+++ b/Doppler.HtmlEditorApi.Test/DopplerHtmlDocumentTest.cs
@@ -80,6 +80,14 @@ public class DopplerHtmlDocumentTest
         "\n  https://google2.com\n   ",
         "https://google2.com"
     )]
+    [InlineData(
+        "%20\n%20  https://google3.com/test%20space%20\n %20  ",
+        "https://google3.com/test%20space"
+    )]
+    [InlineData(
+        "%20\n%20  HTTP://GOOGLE4.com/TEST%20space%20\n %20  ",
+        "http://google4.com/TEST%20space"
+    )]
     public void SanitizeTrackableLinks_should_sanitize_trackable_links(string inputHref, string expectedHref)
     {
         // Arrange

--- a/Doppler.HtmlEditorApi.Test/DopplerHtmlDocumentTest.cs
+++ b/Doppler.HtmlEditorApi.Test/DopplerHtmlDocumentTest.cs
@@ -6,6 +6,92 @@ namespace Doppler.HtmlEditorApi;
 
 public class DopplerHtmlDocumentTest
 {
+    #region Content examples
+    const string HTML_SOCIALSHARE_TABLE_WITH_ERRORS = $@"
+<table>
+    <tr>
+        <td id=""facebook"" valign=""middle"">
+            <a
+                socialshare=""4""
+                ondragstart=""return false;""
+                href=""    http://www.facebook.com/share.php?u=https%3a%2f%2fvp.mydplr.com%2f123&amp;t=Prueba+MSEditor""
+                target=""_blank""
+            >
+                <img
+                ondragstart=""return false;""
+                src=""https://app2.dopplerfiles.com/MSEditor/images/color_small_facebook.png""
+                alt=""Facebook""
+                width=""40""
+                />
+            </a>
+        </td>
+        <td id=""linkedin"" valign=""middle"">
+            <a
+                socialshare=""3""
+                ondragstart=""return false;""
+                href=""
+http://www.linkedin.com/
+shareArticle?mini=true&amp;url=https%3a%2f%2fvp.mydplr.com%2f123&amp;title=Prueba+MSEditor&amp;summary=&amp;source=Add%20to%20Any
+""
+                target=""_blank""
+            >
+                <img
+                ondragstart=""return false;""
+                src=""https://app2.dopplerfiles.com/MSEditor/images/color_small_linkedin.png""
+                alt=""Linkedin""
+                width=""40""
+                />
+            </a>
+        </td>
+        <td id=""pinterest"" valign=""middle"">
+            <a
+                socialshare=""20""
+                ondragstart=""return false;""
+                href=""WRONG URL""
+                target=""_blank""
+            >
+                <img
+                ondragstart=""return false;""
+                src=""https://app2.dopplerfiles.com/MSEditor/images/color_small_pinterest.png""
+                alt=""Pinterest""
+                width=""40""
+                />
+            </a>
+        </td>
+        <td id=""whatsapp"" class=""dplr-mobile-only"" valign=""middle"">
+            <a
+                socialshare=""24""
+                ondragstart=""return false;""
+                href=""whatsapp://send?text=https%3a%2f%2fvp.mydplr.com%2f123""
+                target=""_blank""
+            >
+                <img
+                ondragstart=""return false;""
+                src=""https://app2.dopplerfiles.com/MSEditor/images/color_small_whatsapp.png""
+                alt=""Whatsapp""
+                width=""40""
+                />
+            </a>
+        </td>
+        <td id=""twitter"" valign=""middle"">
+            <a
+                socialshare=""2""
+                ondragstart=""return false;""
+                href=""http://twitter.com/share?related=fromdoppler&amp;text=Prueba+MSEditor&amp;url=https%3a%2f%2fvp.mydplr.com%2f123""
+                target=""_blank""
+            >
+                <img
+                ondragstart=""return false;""
+                src=""https://app2.dopplerfiles.com/MSEditor/images/color_small_twitter.png""
+                alt=""Twitter""
+                width=""40""
+                />
+            </a>
+        </td>
+    </tr>
+</table>";
+    #endregion
+
     private readonly ITestOutputHelper _output;
 
     public DopplerHtmlDocumentTest(ITestOutputHelper output)
@@ -114,6 +200,22 @@ public class DopplerHtmlDocumentTest
 
         // Assert
         Assert.Equal(expected, output);
+    }
+
+    [Fact]
+    public void SanitizeTrackableLinks_should_not_modify_socialshare_links()
+    {
+        // Arrange
+        var input = HTML_SOCIALSHARE_TABLE_WITH_ERRORS;
+        var htmlDocument = new DopplerHtmlDocument(input);
+        var contentWithoutSanitization = htmlDocument.GetDopplerContent();
+
+        // Act
+        htmlDocument.SanitizeTrackableLinks();
+        var output = htmlDocument.GetDopplerContent();
+
+        // Assert
+        Assert.Equal(contentWithoutSanitization, output);
     }
 
     private string CreateTestContentWithLink(string href)

--- a/Doppler.HtmlEditorApi.Test/DopplerHtmlDocumentTest.cs
+++ b/Doppler.HtmlEditorApi.Test/DopplerHtmlDocumentTest.cs
@@ -76,6 +76,10 @@ public class DopplerHtmlDocumentTest
         "HTTPS://GOOGLE.com/   SEGMENT",
         "https://google.com/SEGMENT"
     )]
+    [InlineData(
+        "\n  https://google2.com\n   ",
+        "https://google2.com"
+    )]
     public void SanitizeTrackableLinks_should_sanitize_trackable_links(string inputHref, string expectedHref)
     {
         // Arrange

--- a/Doppler.HtmlEditorApi.Test/DopplerHtmlDocumentTest.cs
+++ b/Doppler.HtmlEditorApi.Test/DopplerHtmlDocumentTest.cs
@@ -50,4 +50,20 @@ public class DopplerHtmlDocumentTest
         // Assert
         Assert.Equal(expectedCount, result.Count());
     }
+
+    [Fact]
+    public void SanitizeTrackableLinks_should_not_modify_html_when_there_are_no_links()
+    {
+        // Arrange
+        var input = $@"<p>Hello!</p>";
+        var htmlDocument = new DopplerHtmlDocument(input);
+        var contentWithoutSanitization = htmlDocument.GetDopplerContent();
+
+        // Act
+        htmlDocument.SanitizeTrackableLinks();
+        var output = htmlDocument.GetDopplerContent();
+
+        // Assert
+        Assert.Equal(contentWithoutSanitization, output);
+    }
 }

--- a/Doppler.HtmlEditorApi.Test/HtmlContentProcessingIntegrationTests.cs
+++ b/Doppler.HtmlEditorApi.Test/HtmlContentProcessingIntegrationTests.cs
@@ -236,6 +236,11 @@ public class HtmlContentProcessingIntegrationTests
         // Sanitization not required
         "<p>Hola <b><a href=\"https://www.google.com/search?q=[[[first name]]]|*|12345678*|*\">[[[first name]]]</a> [[[cumpleaños]]]</b></p>",
         "<p>Hola <b><a href=\"https://www.google.com/search?q=|*|319*|*\">|*|319*|*</a> |*|323*|*</b></p>")]
+    [InlineData(
+        2,
+        "unlayer",
+        "<a href=\"https://\tgoo gle1\n.com    \r\n  \">Link</a>",
+        "<a href=\"https://google1.com\">Link</a>")]
     public async Task PUT_campaign_should_sanitize_links(int idCampaign, string type, string htmlInput, string expectedContent)
     {
         // Arrange

--- a/Doppler.HtmlEditorApi/Controllers/CampaignsController.cs
+++ b/Doppler.HtmlEditorApi/Controllers/CampaignsController.cs
@@ -80,6 +80,7 @@ namespace Doppler.HtmlEditorApi.Controllers
             var htmlDocument = new DopplerHtmlDocument(campaignContent.htmlContent);
             htmlDocument.ReplaceFieldNameTagsByFieldIdTags(dopplerFieldsProcessor.GetFieldIdOrNull);
             htmlDocument.RemoveUnknownFieldIdTags(dopplerFieldsProcessor.FieldIdExist);
+            htmlDocument.SanitizeTrackableLinks();
 
             var head = htmlDocument.GetHeadContent();
             var content = htmlDocument.GetDopplerContent();

--- a/Doppler.HtmlEditorApi/DopplerHtmlDocument.cs
+++ b/Doppler.HtmlEditorApi/DopplerHtmlDocument.cs
@@ -32,8 +32,8 @@ public class DopplerHtmlDocument
     // &, # and ; are here to accept HTML Entities
     private static readonly Regex FIELD_NAME_TAG_REGEX = new Regex($@"{Regex.Escape(FIELD_NAME_TAG_START_DELIMITER)}([a-zA-Z0-9 \-_ñÑáéíóúÁÉÍÓÚ%&;#]+){Regex.Escape(FIELD_NAME_TAG_END_DELIMITER)}");
     private static readonly Regex FIELD_ID_TAG_REGEX = new Regex($@"{Regex.Escape(FIELD_ID_TAG_START_DELIMITER)}(\d+){Regex.Escape(FIELD_ID_TAG_END_DELIMITER)}");
-    private static readonly Regex CLEANUP_URL_REGEX = new Regex(@"\s");
-    private static readonly Regex TRACKABLE_URL_ACCEPTANCE_REGEX = new Regex(@"^\s*(?:https?|ftp):\/\/", RegexOptions.IgnoreCase);
+    private static readonly Regex CLEANUP_URL_REGEX = new Regex(@"^(?:\s?(?:%20)?)*|(?:\s?(?:%20)?)*$|\s");
+    private static readonly Regex TRACKABLE_URL_ACCEPTANCE_REGEX = new Regex(@"^(?:\s?(?:%20)?)*(?:https?|ftp):\/\/", RegexOptions.IgnoreCase);
     private static readonly Regex TRACKABLE_URL_PARTS_REGEX = new Regex(@"^(?<scheme>(?:https?|ftp):\/\/)(?<domain>[^\/]+)(?<rest>\/.*)?$", RegexOptions.IgnoreCase);
 
     private readonly HtmlNode _headNode;

--- a/Doppler.HtmlEditorApi/DopplerHtmlDocument.cs
+++ b/Doppler.HtmlEditorApi/DopplerHtmlDocument.cs
@@ -33,7 +33,7 @@ public class DopplerHtmlDocument
     private static readonly Regex FIELD_NAME_TAG_REGEX = new Regex($@"{Regex.Escape(FIELD_NAME_TAG_START_DELIMITER)}([a-zA-Z0-9 \-_ñÑáéíóúÁÉÍÓÚ%&;#]+){Regex.Escape(FIELD_NAME_TAG_END_DELIMITER)}");
     private static readonly Regex FIELD_ID_TAG_REGEX = new Regex($@"{Regex.Escape(FIELD_ID_TAG_START_DELIMITER)}(\d+){Regex.Escape(FIELD_ID_TAG_END_DELIMITER)}");
     private static readonly Regex CLEANUP_URL_REGEX = new Regex(@"\s");
-    private static readonly Regex TRACKABLE_URL_ACCEPTANCE_REGEX = new Regex(@"^(?:https?|ftp):\/\/", RegexOptions.IgnoreCase);
+    private static readonly Regex TRACKABLE_URL_ACCEPTANCE_REGEX = new Regex(@"^\s*(?:https?|ftp):\/\/", RegexOptions.IgnoreCase);
     private static readonly Regex TRACKABLE_URL_PARTS_REGEX = new Regex(@"^(?<scheme>(?:https?|ftp):\/\/)(?<domain>[^\/]+)(?<rest>\/.*)?$", RegexOptions.IgnoreCase);
 
     private readonly HtmlNode _headNode;

--- a/Doppler.HtmlEditorApi/DopplerHtmlDocument.cs
+++ b/Doppler.HtmlEditorApi/DopplerHtmlDocument.cs
@@ -66,6 +66,7 @@ public class DopplerHtmlDocument
         var trackableLinksNodes = _contentNode
             .GetLinkNodes()
             .Where(x => !string.IsNullOrWhiteSpace(x.Attributes["href"]?.Value))
+            .Where(x => !x.Attributes.Contains("socialshare"))
             .Where(x => TRACKABLE_URL_ACCEPTANCE_REGEX.IsMatch(x.Attributes["href"].Value));
 
         foreach (var node in trackableLinksNodes)

--- a/Doppler.HtmlEditorApi/DopplerHtmlDocument.cs
+++ b/Doppler.HtmlEditorApi/DopplerHtmlDocument.cs
@@ -33,7 +33,8 @@ public class DopplerHtmlDocument
     private static readonly Regex FIELD_NAME_TAG_REGEX = new Regex($@"{Regex.Escape(FIELD_NAME_TAG_START_DELIMITER)}([a-zA-Z0-9 \-_ñÑáéíóúÁÉÍÓÚ%&;#]+){Regex.Escape(FIELD_NAME_TAG_END_DELIMITER)}");
     private static readonly Regex FIELD_ID_TAG_REGEX = new Regex($@"{Regex.Escape(FIELD_ID_TAG_START_DELIMITER)}(\d+){Regex.Escape(FIELD_ID_TAG_END_DELIMITER)}");
     private static readonly Regex CLEANUP_URL_REGEX = new Regex(@"\s");
-    private static readonly Regex TRACKABLE_URL_ACCEPTANCE_REGEX = new Regex(@"^(?:https?|ftp):\/\/");
+    private static readonly Regex TRACKABLE_URL_ACCEPTANCE_REGEX = new Regex(@"^(?:https?|ftp):\/\/", RegexOptions.IgnoreCase);
+    private static readonly Regex TRACKABLE_URL_PARTS_REGEX = new Regex(@"^(?<scheme>(?:https?|ftp):\/\/)(?<domain>[^\/]+)(?<rest>\/.*)?$", RegexOptions.IgnoreCase);
 
     private readonly HtmlNode _headNode;
     private readonly HtmlNode _contentNode;
@@ -112,6 +113,12 @@ public class DopplerHtmlDocument
     {
         var withoutSpaces = CLEANUP_URL_REGEX.Replace(url, string.Empty);
 
-        return withoutSpaces;
+        var match = TRACKABLE_URL_PARTS_REGEX.Match(withoutSpaces);
+        var scheme = match.Groups["scheme"].Value.ToLowerInvariant();
+        var domain = match.Groups["domain"].Value.ToLowerInvariant();
+        var rest = match.Groups["rest"].Value;
+        var sanitizedUrl = $"{scheme}{domain}{rest}";
+
+        return sanitizedUrl;
     }
 }

--- a/Doppler.HtmlEditorApi/DopplerHtmlDocument.cs
+++ b/Doppler.HtmlEditorApi/DopplerHtmlDocument.cs
@@ -58,6 +58,11 @@ public class DopplerHtmlDocument
             .Select(x => int.Parse(x.Groups[1].ValueSpan))
             .Distinct();
 
+    public void SanitizeTrackableLinks()
+    {
+        // TODO: implement me
+    }
+
     public void ReplaceFieldNameTagsByFieldIdTags(Func<string, int?> getFieldIdOrNullFunc)
     {
         _contentNode.TraverseAndReplaceTextsAndAttributeValues(text => FIELD_NAME_TAG_REGEX.Replace(

--- a/Doppler.HtmlEditorApi/DopplerHtmlDocument.cs
+++ b/Doppler.HtmlEditorApi/DopplerHtmlDocument.cs
@@ -32,6 +32,8 @@ public class DopplerHtmlDocument
     // &, # and ; are here to accept HTML Entities
     private static readonly Regex FIELD_NAME_TAG_REGEX = new Regex($@"{Regex.Escape(FIELD_NAME_TAG_START_DELIMITER)}([a-zA-Z0-9 \-_ñÑáéíóúÁÉÍÓÚ%&;#]+){Regex.Escape(FIELD_NAME_TAG_END_DELIMITER)}");
     private static readonly Regex FIELD_ID_TAG_REGEX = new Regex($@"{Regex.Escape(FIELD_ID_TAG_START_DELIMITER)}(\d+){Regex.Escape(FIELD_ID_TAG_END_DELIMITER)}");
+    private static readonly Regex CLEANUP_URL_REGEX = new Regex(@"\s");
+    private static readonly Regex TRACKABLE_URL_ACCEPTANCE_REGEX = new Regex(@"^(?:https?|ftp):\/\/");
 
     private readonly HtmlNode _headNode;
     private readonly HtmlNode _contentNode;
@@ -63,9 +65,7 @@ public class DopplerHtmlDocument
         var trackableLinksNodes = _contentNode
             .GetLinkNodes()
             .Where(x => !string.IsNullOrWhiteSpace(x.Attributes["href"]?.Value))
-            .Where(x => x.Attributes["href"].Value.ToLowerInvariant().StartsWith("http://")
-                || x.Attributes["href"].Value.ToLowerInvariant().StartsWith("https://")
-                || x.Attributes["href"].Value.ToLowerInvariant().StartsWith("ftp://"));
+            .Where(x => TRACKABLE_URL_ACCEPTANCE_REGEX.IsMatch(x.Attributes["href"].Value));
 
         foreach (var node in trackableLinksNodes)
         {
@@ -110,11 +110,7 @@ public class DopplerHtmlDocument
 
     private string SanitizedUrl(string url)
     {
-        var withoutSpaces = url
-            .Replace("\r", string.Empty)
-            .Replace("\n", string.Empty)
-            .Replace("\t", string.Empty)
-            .Replace(" ", string.Empty);
+        var withoutSpaces = CLEANUP_URL_REGEX.Replace(url, string.Empty);
 
         return withoutSpaces;
     }

--- a/Doppler.HtmlEditorApi/DopplerHtmlDocument.cs
+++ b/Doppler.HtmlEditorApi/DopplerHtmlDocument.cs
@@ -60,7 +60,22 @@ public class DopplerHtmlDocument
 
     public void SanitizeTrackableLinks()
     {
-        // TODO: implement me
+        var trackableLinksNodes = _contentNode
+            .GetLinkNodes()
+            .Where(x => !string.IsNullOrWhiteSpace(x.Attributes["href"]?.Value))
+            .Where(x => x.Attributes["href"].Value.ToLowerInvariant().StartsWith("http://")
+                || x.Attributes["href"].Value.ToLowerInvariant().StartsWith("https://")
+                || x.Attributes["href"].Value.ToLowerInvariant().StartsWith("ftp://"));
+
+        foreach (var node in trackableLinksNodes)
+        {
+            var originalHref = node.Attributes["href"].Value;
+            var sanitizedUrl = SanitizedUrl(originalHref);
+            if (sanitizedUrl != originalHref)
+            {
+                node.Attributes["href"].Value = sanitizedUrl;
+            }
+        }
     }
 
     public void ReplaceFieldNameTagsByFieldIdTags(Func<string, int?> getFieldIdOrNullFunc)
@@ -93,4 +108,14 @@ public class DopplerHtmlDocument
     private static string EnsureContent(string htmlContent)
         => string.IsNullOrWhiteSpace(htmlContent) ? "<BR>" : htmlContent;
 
+    private string SanitizedUrl(string url)
+    {
+        var withoutSpaces = url
+            .Replace("\r", string.Empty)
+            .Replace("\n", string.Empty)
+            .Replace("\t", string.Empty)
+            .Replace(" ", string.Empty);
+
+        return withoutSpaces;
+    }
 }

--- a/Doppler.HtmlEditorApi/HtmlAgilityPack/HtmlAgilityPackUtils.cs
+++ b/Doppler.HtmlEditorApi/HtmlAgilityPack/HtmlAgilityPackUtils.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using Doppler.HtmlEditorApi;
 
 namespace HtmlAgilityPack;
 
@@ -53,6 +56,10 @@ public static class HtmlAgilityPackUtils
             textNode.InnerHtml = newText;
         }
     }
+
+    public static IEnumerable<HtmlNode> GetLinkNodes(this HtmlNode node)
+        => node.SelectNodes(@"//a").EmptyIfNull()
+            .Union(node.SelectNodes(@"//area").EmptyIfNull());
 
     public static HtmlDocument LoadHtml(string inputHtml)
     {

--- a/Doppler.HtmlEditorApi/Utils.cs
+++ b/Doppler.HtmlEditorApi/Utils.cs
@@ -14,4 +14,7 @@ public static class Utils
 
     public static IEnumerable<T> EmptyIfNull<T>(this IEnumerable<T> source)
         => source ?? Enumerable.Empty<T>();
+
+    public static string FallbackIfNullOrEmpty(this string source, string fallback)
+        => string.IsNullOrEmpty(source) ? fallback : source;
 }

--- a/Doppler.HtmlEditorApi/Utils.cs
+++ b/Doppler.HtmlEditorApi/Utils.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json;
 
 namespace Doppler.HtmlEditorApi;
@@ -9,4 +11,7 @@ public static class Utils
         using var doc = JsonDocument.Parse(json);
         return doc.RootElement.Clone();
     }
+
+    public static IEnumerable<T> EmptyIfNull<T>(this IEnumerable<T> source)
+        => source ?? Enumerable.Empty<T>();
 }


### PR DESCRIPTION
Hi team!

It reproduces old Doppler behavior sanitizing trackable link URLs.

The behavior is not exactly the same, because I tried to reproduce the original developer objectives but I tried to do it in a cleaner and more robust way.

Description of the new behavior: 

1. It searches the non-empty hrefs attributes in `a` and `area` elements, when it does not have a `socialshare` attribute. 
3. It only takes the href values that start with `http://`, `https://`, `ftp://`, or `www.` (ignoring leading whitespaces and `%20` occourences)
4. It removes leading and trailing occurrences of `%20` (arguable, but Doppler does it)
5. It removes all spaces
6. It converts to lowercase the schema and domain, but keep the case for the rest of the URL
7. When the URL starts with `www.` and scheme is not present, it adds the scheme `http://`

Differences with Doppler behavior:

There are subtle differences, for example in a case like this: `  %20 %20 http://google.com` Doppler was failing to identify the link, but we do.
