### PR TITLE
DE-476 - Link list

### DIFF
--- a/Doppler.HtmlEditorApi.Test/DopplerFieldsProcessorTest.cs
+++ b/Doppler.HtmlEditorApi.Test/DopplerFieldsProcessorTest.cs
@@ -1,0 +1,50 @@
+using Xunit;
+
+namespace Doppler.HtmlEditorApi;
+
+public class DopplerFieldsProcessorTest
+{
+    private static DopplerFieldsProcessor CreateSut()
+        => new DopplerFieldsProcessor(
+            fields: new[]
+            {
+                new Field(1, "FIELD_1", true),
+                new Field(2, "FIELD_2", true),
+                new Field(345, "custom1", false),
+                new Field(456, "custom2", false),
+            },
+            aliasesByCanonical: new[]
+            {
+                new FieldAliasesDef()
+                {
+                    canonicalName = "FIELD_1",
+                    aliases = new[] { "FIELD_A", "FIELD 1" }
+                },
+                new FieldAliasesDef()
+                {
+                    canonicalName = "FIELD_2",
+                    aliases = new[] { "FIELD_B", "FIELD 2" }
+                },
+            }
+        );
+
+    [Theory]
+    [InlineData(1, "FIELD_1")]
+    [InlineData(2, "FIELD_2")]
+    [InlineData(345, "custom1")]
+    [InlineData(456, "custom2")]
+    [InlineData(5, null)]
+    [InlineData(1234, null)]
+    public void GetFieldNameOrNull_should_return_names_of_known_fields_and_null_for_unknown_ones(int fieldId, string expectedFieldName)
+    {
+        // Arrange
+        var sut = CreateSut();
+
+        // Act
+        var result = sut.GetFieldNameOrNull(fieldId);
+
+        // Assert
+        Assert.Equal(expectedFieldName, result);
+    }
+
+}

--- a/Doppler.HtmlEditorApi.Test/DopplerHtmlDocumentTest.cs
+++ b/Doppler.HtmlEditorApi.Test/DopplerHtmlDocumentTest.cs
@@ -232,6 +232,58 @@ shareArticle?mini=true&amp;url=https%3a%2f%2fvp.mydplr.com%2f123&amp;title=Prueb
         Assert.Equal(contentWithoutSanitization, output);
     }
 
+    [Fact]
+    public void GetTrackableUrls_should_return_empty_list_when_there_are_not_links()
+    {
+        // Arrange
+        var input = "<p>Hello!</p>";
+        var htmlDocument = new DopplerHtmlDocument(input);
+        htmlDocument.GetDopplerContent();
+
+        // Act
+        var links = htmlDocument.GetTrackableUrls();
+
+        // Assert
+        Assert.Empty(links);
+    }
+
+    [Fact]
+    public void GetTrackableUrls_should_return_empty_list_when_there_are_only_socialshare_links()
+    {
+        // Arrange
+        var input = HTML_SOCIALSHARE_TABLE_WITH_ERRORS;
+        var htmlDocument = new DopplerHtmlDocument(input);
+        htmlDocument.GetDopplerContent();
+
+        // Act
+        var links = htmlDocument.GetTrackableUrls();
+
+        // Assert
+        Assert.Empty(links);
+    }
+
+    [Fact]
+    public void GetTrackableUrls_should_return_list_of_trackable_urls()
+    {
+        // Arrange
+        var input = @"<ul>
+    <li><a href=""https://www.google.com/search?q=search%20term"">Result 1 (HTTPS)</a></li>
+    <li><a href=""HTTP://www.GOOGLE.com/search?q=SEARCH%20term"">Result 2 (HTTP, with uppercase)</a></li>
+    <li><a href=""www.GOOGLE.com/search?q=SEARCH%20term"">Result 3 (with www without scheme)</a></li>
+    <li><a href=""GOOGLE.com/search?q=SEARCH%20term"">No Result (without www without scheme)</a></li>
+    <li><a href=""ftp://GOOGLE.com/search?q=SEARCH%20term"">Result 4 (ftp)</a></li>
+    <li><a href=""www.GOOGLE.com/search?q=SEARCH%20term"">No Result (duplicated)</a></li>
+</ul>";
+        var htmlDocument = new DopplerHtmlDocument(input);
+        htmlDocument.GetDopplerContent();
+
+        // Act
+        var links = htmlDocument.GetTrackableUrls();
+
+        // Assert
+        Assert.Equal(4, links.Count());
+    }
+
     private string CreateTestContentWithLink(string href)
         => $@"<div>
     <a href=""{href}"">Link</a>

--- a/Doppler.HtmlEditorApi/Controllers/CampaignsController.cs
+++ b/Doppler.HtmlEditorApi/Controllers/CampaignsController.cs
@@ -82,6 +82,9 @@ namespace Doppler.HtmlEditorApi.Controllers
             htmlDocument.RemoveUnknownFieldIdTags(dopplerFieldsProcessor.FieldIdExist);
             htmlDocument.SanitizeTrackableLinks();
 
+            // TODO: use and test it
+            var trackableUrls = htmlDocument.GetTrackableUrls(dopplerFieldsProcessor.GetFieldNameOrNull);
+
             var head = htmlDocument.GetHeadContent();
             var content = htmlDocument.GetDopplerContent();
             var fieldIds = htmlDocument.GetFieldsIdOrNull();

--- a/Doppler.HtmlEditorApi/DopplerFieldsProcessor.cs
+++ b/Doppler.HtmlEditorApi/DopplerFieldsProcessor.cs
@@ -29,6 +29,11 @@ public class DopplerFieldsProcessor
             ? fieldId
             : null;
 
+    public string GetFieldNameOrNull(int fieldId)
+        => _fieldNamesById.TryGetValue(fieldId, out var fieldName)
+            ? fieldName
+            : null;
+
     public bool FieldIdExist(int fieldId)
         => _fieldNamesById.ContainsKey(fieldId);
 

--- a/Doppler.HtmlEditorApi/DopplerHtmlDocument.cs
+++ b/Doppler.HtmlEditorApi/DopplerHtmlDocument.cs
@@ -70,11 +70,7 @@ public class DopplerHtmlDocument
 
     public void SanitizeTrackableLinks()
     {
-        var trackableLinksNodes = _contentNode
-            .GetLinkNodes()
-            .Where(x => !string.IsNullOrWhiteSpace(x.Attributes["href"]?.Value))
-            .Where(x => !x.Attributes.Contains("socialshare"))
-            .Where(x => TRACKABLE_URL_ACCEPTANCE_REGEX.IsMatch(x.Attributes["href"].Value));
+        var trackableLinksNodes = GetTrackableLinkNodes();
 
         foreach (var node in trackableLinksNodes)
         {
@@ -133,4 +129,11 @@ public class DopplerHtmlDocument
 
         return sanitizedUrl;
     }
+
+    private IEnumerable<HtmlNode> GetTrackableLinkNodes()
+        => _contentNode
+            .GetLinkNodes()
+            .Where(x => !string.IsNullOrWhiteSpace(x.Attributes["href"]?.Value))
+            .Where(x => !x.Attributes.Contains("socialshare"))
+            .Where(x => TRACKABLE_URL_ACCEPTANCE_REGEX.IsMatch(x.Attributes["href"].Value));
 }

--- a/Doppler.HtmlEditorApi/DopplerHtmlDocument.cs
+++ b/Doppler.HtmlEditorApi/DopplerHtmlDocument.cs
@@ -68,6 +68,11 @@ public class DopplerHtmlDocument
             .Distinct();
     }
 
+    public IEnumerable<string> GetTrackableUrls()
+        => GetTrackableLinkNodes()
+            .Select(x => x.Attributes["href"].Value)
+            .Distinct();
+
     public void SanitizeTrackableLinks()
     {
         var trackableLinksNodes = GetTrackableLinkNodes();


### PR DESCRIPTION
Hi team!

I have already sanitized the links in #70, now I am reading them to then (in further PR) insert them in the database.

When it reads the links, it transforms back the internal field representation (`|*|{ID}*|*`) into the public representation  (`[[[name]]]`) using the canonical field name.

