### PR TITLE
fix: do not map field ids to field names on GetTrackableUrls()

### DIFF
--- a/Doppler.HtmlEditorApi.Test/DopplerHtmlDocumentTest.cs
+++ b/Doppler.HtmlEditorApi.Test/DopplerHtmlDocumentTest.cs
@@ -241,7 +241,7 @@ shareArticle?mini=true&amp;url=https%3a%2f%2fvp.mydplr.com%2f123&amp;title=Prueb
         htmlDocument.GetDopplerContent();
 
         // Act
-        var links = htmlDocument.GetTrackableUrls(_ => null);
+        var links = htmlDocument.GetTrackableUrls();
 
         // Assert
         Assert.Empty(links);
@@ -256,7 +256,7 @@ shareArticle?mini=true&amp;url=https%3a%2f%2fvp.mydplr.com%2f123&amp;title=Prueb
         htmlDocument.GetDopplerContent();
 
         // Act
-        var links = htmlDocument.GetTrackableUrls(_ => null);
+        var links = htmlDocument.GetTrackableUrls();
 
         // Assert
         Assert.Empty(links);
@@ -278,64 +278,36 @@ shareArticle?mini=true&amp;url=https%3a%2f%2fvp.mydplr.com%2f123&amp;title=Prueb
         htmlDocument.GetDopplerContent();
 
         // Act
-        var links = htmlDocument.GetTrackableUrls(_ => null);
+        var links = htmlDocument.GetTrackableUrls();
 
         // Assert
         Assert.Equal(4, links.Count());
     }
 
     [Fact]
-    public void GetTrackableUrls_should_map_fieldnames()
+    public void GetTrackableUrls_should_not_map_fieldnames()
     {
         // Arrange
         var input = @"<ul>
     <li><a href=""https://www.|*|123*|*.com/search?q=|*|456*|*"">Result 1 (HTTPS)</a></li>
     <li><a href=""HTTP://|*|1*|*/search?q=SEARCH%20term"">Result 2 (HTTP, with uppercase)</a></li>
-    <li><a href=""www.GOOGLE.com/|*|2*|*"">Result 3 (with www without scheme)</a></li>
+    <li><a href=""www.GOOGLE.com/[[[field]]]"">Result 3 (with www without scheme)</a></li>
     <li><a href=""ftp://|*|3*|*"">Result 4 (ftp)</a></li>
 </ul>";
         var htmlDocument = new DopplerHtmlDocument(input);
         htmlDocument.GetDopplerContent();
 
         // Act
-        var links = htmlDocument.GetTrackableUrls(fieldId => $"FIELD_{fieldId}");
-
-        // Assert
-        Assert.Collection(
-            links,
-            link => Assert.Equal("https://www.[[[FIELD_123]]].com/search?q=[[[FIELD_456]]]", link),
-            link => Assert.Equal("HTTP://[[[FIELD_1]]]/search?q=SEARCH%20term", link),
-            link => Assert.Equal("www.GOOGLE.com/[[[FIELD_2]]]", link),
-            link => Assert.Equal("ftp://[[[FIELD_3]]]", link));
-    }
-
-    [Fact]
-    public void GetTrackableUrls_should_keep_original_code_when_fieldname_does_not_exist()
-    {
-        // Arrange
-        var input = @"<ul>
-    <li><a href=""https://www.|*|123*|*.com/search?q=|*|456*|*"">Result 1 (HTTPS)</a></li>
-    <li><a href=""HTTP://|*|1*|*/search?q=SEARCH%20term"">Result 2 (HTTP, with uppercase)</a></li>
-    <li><a href=""www.GOOGLE.com/|*|2*|*"">Result 3 (with www without scheme)</a></li>
-    <li><a href=""ftp://|*|3*|*"">Result 4 (ftp)</a></li>
-</ul>";
-        var htmlDocument = new DopplerHtmlDocument(input);
-        htmlDocument.GetDopplerContent();
-
-        // Act
-        var links = htmlDocument.GetTrackableUrls(_ => null);
+        var links = htmlDocument.GetTrackableUrls();
 
         // Assert
         Assert.Collection(
             links,
             link => Assert.Equal("https://www.|*|123*|*.com/search?q=|*|456*|*", link),
             link => Assert.Equal("HTTP://|*|1*|*/search?q=SEARCH%20term", link),
-            link => Assert.Equal("www.GOOGLE.com/|*|2*|*", link),
+            link => Assert.Equal("www.GOOGLE.com/[[[field]]]", link),
             link => Assert.Equal("ftp://|*|3*|*", link));
     }
-
-    // private string DummyGetFieldNameOrNullFunc(int fieldId)
-    //     => $"FIELD_{fieldId}";
 
     private string CreateTestContentWithLink(string href)
         => $@"<div>

--- a/Doppler.HtmlEditorApi/Controllers/CampaignsController.cs
+++ b/Doppler.HtmlEditorApi/Controllers/CampaignsController.cs
@@ -83,7 +83,7 @@ namespace Doppler.HtmlEditorApi.Controllers
             htmlDocument.SanitizeTrackableLinks();
 
             // TODO: use and test it
-            var trackableUrls = htmlDocument.GetTrackableUrls(dopplerFieldsProcessor.GetFieldNameOrNull);
+            var trackableUrls = htmlDocument.GetTrackableUrls();
 
             var head = htmlDocument.GetHeadContent();
             var content = htmlDocument.GetDopplerContent();

--- a/Doppler.HtmlEditorApi/DopplerHtmlDocument.cs
+++ b/Doppler.HtmlEditorApi/DopplerHtmlDocument.cs
@@ -61,18 +61,9 @@ public class DopplerHtmlDocument
             .Select(x => int.Parse(x.Groups[1].ValueSpan))
             .Distinct();
 
-    public IEnumerable<string> GetTrackableUrls(Func<int, string> getFieldNameOrNullFunc)
+    public IEnumerable<string> GetTrackableUrls()
         => GetTrackableLinkNodes()
             .Select(x => x.Attributes["href"].Value)
-            .Select(x => FIELD_ID_TAG_REGEX.Replace(x, match =>
-            {
-                var fieldId = int.Parse(match.Groups[1].ValueSpan);
-                var fieldName = getFieldNameOrNullFunc(fieldId);
-                return fieldName != null
-                    ? CreateFieldNameTag(fieldName)
-                    // keep the original code when field doesn't exist
-                    : match.Value;
-            }))
             .Distinct();
 
     public void SanitizeTrackableLinks()
@@ -116,9 +107,6 @@ public class DopplerHtmlDocument
 
     private static string CreateFieldIdTag(int? fieldId)
         => $"{FIELD_ID_TAG_START_DELIMITER}{fieldId}{FIELD_ID_TAG_END_DELIMITER}";
-
-    private static string CreateFieldNameTag(string fieldName)
-        => $"{FIELD_NAME_TAG_START_DELIMITER}{fieldName}{FIELD_NAME_TAG_END_DELIMITER}";
 
     private static string EnsureContent(string htmlContent)
         => string.IsNullOrWhiteSpace(htmlContent) ? "<BR>" : htmlContent;


### PR DESCRIPTION
I was confused when I review the old Doppler code, when we obtain the trackable links, they should be in raw format (I mean, with the id in place of the name) as you can see in the image:

![image](https://user-images.githubusercontent.com/1157864/159726830-91d2bb33-3ba2-4039-8eb7-2ac3daab1861.png)

So, I am removing the wrong behavior in this PR.