### PR TITLE
DE-530 - Delete removed links and related AutomationConditionals

### DIFF
--- a/Doppler.HtmlEditorApi.Test/SaveCampaignTest.cs
+++ b/Doppler.HtmlEditorApi.Test/SaveCampaignTest.cs
@@ -632,6 +632,14 @@ namespace Doppler.HtmlEditorApi
             ), Times.Once);
             Assert.Equal(expectedLinks, linksSendToSaveNewCampaignLinks);
 
+            string[] linksSendToDeleteAutomationConditionalsOfRemovedCampaignLinks = null;
+            dbContextMock.Verify(x => x.ExecuteAsync(
+                It.Is<DeleteAutomationConditionalsOfRemovedCampaignLinks>(q =>
+                    q.IdContent == expectedIdCampaign
+                    && AssertHelper.GetValueAndContinue(q.Links.ToArray(), out linksSendToDeleteAutomationConditionalsOfRemovedCampaignLinks))
+            ), Times.Once);
+            Assert.Equal(expectedLinks, linksSendToDeleteAutomationConditionalsOfRemovedCampaignLinks);
+
             string[] linksSendToDeleteRemovedCampaignLinks = null;
             dbContextMock.Verify(x => x.ExecuteAsync(
                 It.Is<DeleteRemovedCampaignLinks>(q =>
@@ -731,6 +739,12 @@ namespace Doppler.HtmlEditorApi
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             dbContextMock.VerifyAll();
+
+            dbContextMock.Verify(x => x.ExecuteAsync(
+                It.Is<DeleteAutomationConditionalsOfRemovedCampaignLinks>(q =>
+                    q.IdContent == expectedIdCampaign
+                    && !q.Links.Any())
+            ), Times.Once);
 
             dbContextMock.Verify(x => x.ExecuteAsync(
                 It.Is<DeleteRemovedCampaignLinks>(q =>

--- a/Doppler.HtmlEditorApi/Storage.DapperProvider/DapperCampaignContentRepository.cs
+++ b/Doppler.HtmlEditorApi/Storage.DapperProvider/DapperCampaignContentRepository.cs
@@ -143,8 +143,7 @@ public class DapperCampaignContentRepository : ICampaignContentRepository
         {
             await _dbContext.ExecuteAsync(new SaveNewCampaignLinks(ContentId, links));
         }
-        // TODO: Delete removed links from AutomationConditional table
-        // See https://github.com/MakingSense/Doppler/blob/ed24e901c990b7fb2eaeaed557c62c1adfa80215/Doppler.Application.CampaignsModule/Services/Classes/CampaignContentService.cs#L2519-L2523
+        await _dbContext.ExecuteAsync(new DeleteAutomationConditionalsOfRemovedCampaignLinks(ContentId, links));
         await _dbContext.ExecuteAsync(new DeleteRemovedCampaignLinks(ContentId, links));
     }
 }

--- a/Doppler.HtmlEditorApi/Storage.DapperProvider/DapperCampaignContentRepository.cs
+++ b/Doppler.HtmlEditorApi/Storage.DapperProvider/DapperCampaignContentRepository.cs
@@ -143,6 +143,8 @@ public class DapperCampaignContentRepository : ICampaignContentRepository
         {
             await _dbContext.ExecuteAsync(new SaveNewCampaignLinks(ContentId, links));
         }
-        // TODO: delete not included links
+        // TODO: Delete removed links from AutomationConditional table
+        // See https://github.com/MakingSense/Doppler/blob/ed24e901c990b7fb2eaeaed557c62c1adfa80215/Doppler.Application.CampaignsModule/Services/Classes/CampaignContentService.cs#L2519-L2523
+        await _dbContext.ExecuteAsync(new DeleteRemovedCampaignLinks(ContentId, links));
     }
 }

--- a/Doppler.HtmlEditorApi/Storage.DapperProvider/Queries/DeleteAutomationConditionalsOfRemovedCampaignLinks.cs
+++ b/Doppler.HtmlEditorApi/Storage.DapperProvider/Queries/DeleteAutomationConditionalsOfRemovedCampaignLinks.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+
+namespace Doppler.HtmlEditorApi.Storage.DapperProvider.Queries;
+
+/// <summary>
+/// It deletes AutomationConditional link entries that are not present in the payload.
+/// It does not insert or update nothing else.
+/// </summary>
+/// <remarks>
+/// Dapper deals with the SQL `IN` operator and the IEnumerable.
+/// (See https://github.com/DapperLib/Dapper#list-support)
+/// Example with 4 links:
+///     exec sp_executesql N'
+///       DELETE ac
+///       FROM [AutomationConditional] ac
+///       INNER JOIN [Link] l ON ac.IdLink = l.IdLink
+///       WHERE l.IdCampaign = @IdContent
+///       AND l.UrlLink NOT IN (@Links1,@Links2,@Links3,@Links4)',
+///     N'@IdContent int,@Links1 nvarchar(4000),@Links2 nvarchar(4000),@Links3 nvarchar(4000),@Links4 nvarchar(4000)',
+///     @IdContent=36357513,@Links1=N'https://www.google.com?q=|*|320*|*',@Links2=N'a',@Links3=N'b',@Links4=N'c'
+/// Example without links:
+///     exec sp_executesql N'
+///       DELETE ac
+///       FROM [AutomationConditional] ac
+///       INNER JOIN [Link] l ON ac.IdLink = l.IdLink
+///       WHERE l.IdCampaign = @IdContent
+///       AND l.UrlLink NOT IN (SELECT @Links WHERE 1 = 0)',
+///     N'@IdContent int,@Links nvarchar(4000)',
+///     @IdContent=36357513,@Links=NULL
+/// </remarks>
+public record DeleteAutomationConditionalsOfRemovedCampaignLinks(
+    int IdContent,
+    IEnumerable<string> Links
+) : IExecutableDbQuery
+{
+    public string GenerateSqlQuery() => @"
+DELETE ac
+FROM [AutomationConditional] ac
+INNER JOIN [Link] l ON ac.IdLink = l.IdLink
+WHERE l.IdCampaign = @IdContent
+AND l.UrlLink NOT IN @Links
+";
+}

--- a/Doppler.HtmlEditorApi/Storage.DapperProvider/Queries/DeleteRemovedCampaignLinks.cs
+++ b/Doppler.HtmlEditorApi/Storage.DapperProvider/Queries/DeleteRemovedCampaignLinks.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+
+namespace Doppler.HtmlEditorApi.Storage.DapperProvider.Queries;
+
+/// <summary>
+/// It deletes DB entries that are not present in the payload.
+/// It does not insert or update nothing else.
+/// </summary>
+/// <remarks>
+/// Dapper deals with the SQL `IN` operator and the IEnumerable.
+/// (See https://github.com/DapperLib/Dapper#list-support)
+/// Example with 4 links:
+///     exec sp_executesql N'
+///       DELETE FROM [Link]
+///       WHERE [Link].IdCampaign = @IdContent
+///       AND [Link].UrlLink NOT IN (@Links1,@Links2,@Links3,@Links4)',
+///     N'@IdContent int,@Links1 nvarchar(4000),@Links2 nvarchar(4000),@Links3 nvarchar(4000),@Links4 nvarchar(4000)',
+///     @IdContent=36357513,@Links1=N'https://www.google.com?q=|*|320*|*',@Links2=N'a',@Links3=N'b',@Links4=N'c'
+/// Example without links:
+///     exec sp_executesql N'
+///       DELETE FROM [Link]
+///       WHERE [Link].IdCampaign = @IdContent
+///       AND [Link].UrlLink NOT IN (SELECT @Links WHERE 1 = 0)',
+///     N'@IdContent int,@Links nvarchar(4000)',
+///     @IdContent=36357513,@Links=NULL
+/// </remarks>
+public record DeleteRemovedCampaignLinks(
+    int IdContent,
+    IEnumerable<string> Links
+) : IExecutableDbQuery
+{
+    public string GenerateSqlQuery() => @"
+DELETE FROM [Link]
+WHERE [Link].IdCampaign = @IdContent
+AND [Link].UrlLink NOT IN @Links
+";
+}


### PR DESCRIPTION
Hi team!

This is the query to delete the links removed from the campaign content.

It was easier than insert because of a [Dapper feature](https://github.com/DapperLib/Dapper#list-support). It is not so predictable, so I have added a code comment with the explanation.

It is pending:
- [x] to remove the links from automation conditionals