### PR TITLE
[DE-478] Denegar la edición de campañas con estados no permitidos

### DIFF
--- a/Doppler.HtmlEditorApi.Test/Storage/Queries/DapperProvider/DapperCampaignContentRepositoryTest.cs
+++ b/Doppler.HtmlEditorApi.Test/Storage/Queries/DapperProvider/DapperCampaignContentRepositoryTest.cs
@@ -1,0 +1,56 @@
+using Doppler.HtmlEditorApi;
+using Doppler.HtmlEditorApi.Storage.DapperProvider;
+using Doppler.HtmlEditorApi.Storage.DapperProvider.Queries;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Moq;
+using Xunit;
+
+namespace Doppler.HtmlEditorApi.Storage.DapperProvider;
+
+public class DapperCampaignContentRepositoryTest : IClassFixture<WebApplicationFactory<Startup>>
+{
+    [Theory]
+    [InlineData(null, false)]
+    [InlineData(1, true)] //DRAFT
+    [InlineData(2, false)]
+    [InlineData(3, false)]
+    [InlineData(4, false)]
+    [InlineData(5, false)]
+    [InlineData(6, false)]
+    [InlineData(7, false)]
+    [InlineData(8, false)]
+    [InlineData(9, false)]
+    [InlineData(10, false)]
+    [InlineData(11, true)]//DRAFT
+    [InlineData(12, false)]
+    [InlineData(13, false)]
+    [InlineData(14, false)]
+    [InlineData(15, false)]
+    [InlineData(16, false)]
+    [InlineData(17, false)]
+    [InlineData(18, true)] //IN_WINNER_SELECTION_PROCESS
+    [InlineData(19, false)]
+    [InlineData(20, false)]
+    [InlineData(21, false)]
+    [InlineData(22, false)]
+    public async void GetCampaignState_with_content_writable_when_valid_doppler_status_code(int? dopplerCampaignStatus, bool expectedIsWritable)
+    {
+        var dbContextMock = new Mock<IDbContext>();
+        dbContextMock
+            .Setup(x => x.ExecuteAsync(
+                new FirstOrDefaultCampaignStatusDbQuery(It.IsAny<int>(), It.IsAny<string>()))
+                )
+            .ReturnsAsync(new FirstOrDefaultCampaignStatusDbQuery.Result()
+            {
+                OwnCampaignExists = true,
+                ContentExists = true,
+                EditorType = 5,
+                Status = dopplerCampaignStatus
+            });
+        var repository = new DapperCampaignContentRepository(dbContextMock.Object);
+
+        var campaignState = await repository.GetCampaignState(It.IsAny<string>(), It.IsAny<int>());
+        Assert.Equal(expectedIsWritable, campaignState.IsWritable);
+        dbContextMock.VerifyAll();
+    }
+}

--- a/Doppler.HtmlEditorApi/CampaignState.cs
+++ b/Doppler.HtmlEditorApi/CampaignState.cs
@@ -1,0 +1,17 @@
+using System.Linq;
+using System;
+using System.Collections.Generic;
+
+namespace Doppler.HtmlEditorApi;
+
+public record CampaignState(bool OwnCampaignExists, bool ContentExists, int? EditorType, CampaignStatus? CampaignStatus)
+{
+    private static readonly HashSet<CampaignStatus> WritableStatus = new HashSet<CampaignStatus>
+    (new[]
+        {
+            HtmlEditorApi.CampaignStatus.DRAFT,
+            HtmlEditorApi.CampaignStatus.IN_WINNER_IN_AB_SELECTION_PROCESS
+        });
+    public bool IsWritable => CampaignStatus.HasValue && WritableStatus.Contains(CampaignStatus.Value);
+}
+public record NoExistCampaignState() : CampaignState(false, false, null, null);

--- a/Doppler.HtmlEditorApi/CampaignStatus.cs
+++ b/Doppler.HtmlEditorApi/CampaignStatus.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Doppler.HtmlEditorApi;
+
+public enum CampaignStatus
+{
+    DRAFT,
+    IN_WINNER_IN_AB_SELECTION_PROCESS,
+    OTHER
+}
+
+

--- a/Doppler.HtmlEditorApi/Storage.DapperProvider/DapperCampaignContentRepository.cs
+++ b/Doppler.HtmlEditorApi/Storage.DapperProvider/DapperCampaignContentRepository.cs
@@ -103,12 +103,6 @@ public class DapperCampaignContentRepository : ICampaignContentRepository
             IdCampaign: contentRow.campaignId
         ));
 
-        // TODO: consider returning 404 NotFound
-        if (campaignStatus == null || !campaignStatus.OwnCampaignExists)
-        {
-            throw new ApplicationException($"CampaignId {contentRow.campaignId} does not exists or belongs to another user than {accountName}");
-        }
-
         var queryParams = contentRow switch
         {
             UnlayerContentData unlayerContentData => new

--- a/Doppler.HtmlEditorApi/Storage.DapperProvider/Queries/FirstOrDefaultCampaignStatusDbQuery.cs
+++ b/Doppler.HtmlEditorApi/Storage.DapperProvider/Queries/FirstOrDefaultCampaignStatusDbQuery.cs
@@ -11,7 +11,8 @@ public record FirstOrDefaultCampaignStatusDbQuery(
 SELECT
     CAST (CASE WHEN ca.IdCampaign IS NULL THEN 0 ELSE 1 END AS BIT) AS OwnCampaignExists,
     CAST (CASE WHEN co.IdCampaign IS NULL THEN 0 ELSE 1 END AS BIT) AS ContentExists,
-    co.EditorType
+    co.EditorType,
+    ca.Status
 FROM [User] u
 LEFT JOIN [Campaign] ca ON
     u.IdUser = ca.IdUser
@@ -25,5 +26,6 @@ WHERE u.Email = @accountName";
         public bool OwnCampaignExists { get; init; }
         public bool ContentExists { get; init; }
         public int? EditorType { get; init; }
+        public int? Status { get; init; }
     }
 }

--- a/Doppler.HtmlEditorApi/Storage/ICampaignContentRepository.cs
+++ b/Doppler.HtmlEditorApi/Storage/ICampaignContentRepository.cs
@@ -5,6 +5,7 @@ namespace Doppler.HtmlEditorApi.Storage;
 
 public interface ICampaignContentRepository
 {
+    Task<CampaignState> GetCampaignState(string accountName, int campaignId);
     Task<ContentData> GetCampaignModel(string accountName, int campaignId);
     Task SaveCampaignContent(string accountName, ContentData contentRow);
 


### PR DESCRIPTION
Se agrega la verificación del estado de una campaña para permitir o denegar la edición del contenido de acuerdo a la homologación de los [estados manejados en Doppler](https://github.com/MakingSense/Doppler/blob/develop/Doppler.Transversal/Classes/CampaignStatusEnum.cs). Para la homologación se abstrajo la [lógica de Doppler](https://github.com/MakingSense/Doppler/blob/ed24e901c990b7fb2eaeaed557c62c1adfa80215/Doppler.Application.CampaignsModule/Services/Classes/CampaignContentService.cs#L2506-L2509).

⚠️ _**Importante,**_ el manejo de estados en esta api se construirá homologando los estados que maneja Doppler, esto significa que es necesario hacer un análisis de los estados antes de agregarlos acá teniendo en cuenta [CampaignShippingStatus.cs](https://github.com/MakingSense/Doppler/blob/develop/Doppler.HypermediaAPI/Model/Enums/CampaignShippingStatus.cs), [CampaignStatusEnum.cs](https://github.com/MakingSense/Doppler/blob/develop/Doppler.Transversal/Classes/CampaignStatusEnum.cs) y [CampaignStatus.cs](https://github.com/MakingSense/Doppler/blob/develop/Doppler.HypermediaAPI/Model/Enums/CampaignStatus.cs)

(1° E.g) el estado **_IN_WINNER_SELECTION_PROCESS_** de [_Doppler_ ](https://github.com/MakingSense/Doppler)se llama acá como **_IN_WINNER_IN_AB_SELECTION_PROCESS_** 
(2° E.g) En [Doppler ](https://github.com/MakingSense/Doppler)hay dos estados para _DRAFT_ _(son **DRAFT y DRAFT_TEST_AB**)_ mientras acá la API solo se llama **_DRAFT_**