### PR TITLE
WIP: [DE-478] refactorización del metodo saveCampaignContent

### DIFF
--- a/Doppler.HtmlEditorApi/Controllers/CampaignsController.cs
+++ b/Doppler.HtmlEditorApi/Controllers/CampaignsController.cs
@@ -119,7 +119,14 @@ namespace Doppler.HtmlEditorApi.Controllers
                 _ => throw new NotImplementedException($"Unsupported campaign content type {campaignContent.type:G}")
             };
 
-            await _campaignContentRepository.SaveCampaignContent(accountName, contentRow);
+            if (campaignState.ContentExists)
+            {
+                await _campaignContentRepository.UpdateCampaignContent(accountName, contentRow);
+            }
+            else
+            {
+                await _campaignContentRepository.CreateCampaignContent(accountName, contentRow);
+            }
             await _campaignContentRepository.SaveNewFieldIds(campaignId, fieldIds);
             await _campaignContentRepository.SaveLinks(campaignId, trackableUrls);
 

--- a/Doppler.HtmlEditorApi/Repositories/ICampaignContentRepository.cs
+++ b/Doppler.HtmlEditorApi/Repositories/ICampaignContentRepository.cs
@@ -8,7 +8,8 @@ public interface ICampaignContentRepository
 {
     Task<CampaignState> GetCampaignState(string accountName, int campaignId);
     Task<ContentData> GetCampaignModel(string accountName, int campaignId);
-    Task SaveCampaignContent(string accountName, ContentData contentRow);
+    Task CreateCampaignContent(string accountName, ContentData contentRow);
+    Task UpdateCampaignContent(string accountName, ContentData contentRow);
 
     /// <summary>
     /// It keeps existing DB entries and only adds new ones without deleting anything.


### PR DESCRIPTION
Para evitar una consulta doble del estado de una campaña se ve oportuno separar el método `saveCampaignContent()` en dos métodos _(update, create)_ y que el controlador que es quien conoce la información del estado de una campaña se encargue de decidir que método usar.