### PR TITLE
fix: use rootNode in place of contentNode to remove harmfultags

### DIFF
--- a/Doppler.HtmlEditorApi.Test/Domain/DopplerHtmlDocumentTest.cs
+++ b/Doppler.HtmlEditorApi.Test/Domain/DopplerHtmlDocumentTest.cs
@@ -316,11 +316,11 @@ shareArticle?mini=true&amp;url=https%3a%2f%2fvp.mydplr.com%2f123&amp;title=Prueb
 <article>
     <h1>Title</h1>
     <p>This is a paragraph</p>
-    <p>This is another paragraph <script>script</script> with a script</p>
-    <script>another script</script>
+    <p>This is another paragraph <SCRIPT>script</SCRIPT> with a script</p>
+    <SCRIPT>another script</SCRIPT>
     <embed>embed tag should not be closed</embed>
-    <iframe />
-    <iframe title=""Inline Frame Example"" src=""malicious.html""></iframe>
+    <IFRAME />
+    <IFRAME title=""Inline Frame Example"" src=""malicious.html""></IFRAME>
 </article>",
         @"
 <article>
@@ -385,7 +385,7 @@ shareArticle?mini=true&amp;url=https%3a%2f%2fvp.mydplr.com%2f123&amp;title=Prueb
         @"<p>paragraph 1</p></iframe><p>paragraph 2</p>",
         @"<p>paragraph 1</p><p>paragraph 2</p>")]
     [InlineDataAttribute(
-        @"<p>paragraph 1</p><script /><p>paragraph 2</p>",
+        @"<p>paragraph 1</p><SCRIPT /><p>paragraph 2</p>",
         @"<p>paragraph 1</p>")]
     [InlineDataAttribute(
         @"<p>paragraph 1</p><script><p>paragraph 2</p>",
@@ -397,7 +397,7 @@ shareArticle?mini=true&amp;url=https%3a%2f%2fvp.mydplr.com%2f123&amp;title=Prueb
         @"<p>paragraph 1</p><embed /><p>paragraph 2</p>",
         @"<p>paragraph 1</p><p>paragraph 2</p>")]
     [InlineDataAttribute(
-        @"<p>paragraph 1</p><embed><p>paragraph 2</p>",
+        @"<p>paragraph 1</p><EMBED><p>paragraph 2</p>",
         @"<p>paragraph 1</p><p>paragraph 2</p>")]
     [InlineDataAttribute(
         @"<p>paragraph 1</p></embed><p>paragraph 2</p>",
@@ -428,7 +428,7 @@ shareArticle?mini=true&amp;url=https%3a%2f%2fvp.mydplr.com%2f123&amp;title=Prueb
         @"
 <html>
 <head>
-    <iframe></iframe>
+    <IFRAME></IFRAME>
     <embed>
     <title>Hello safety!</title>
     <script>script in the head</script>

--- a/Doppler.HtmlEditorApi/Domain/DopplerHtmlDocument.cs
+++ b/Doppler.HtmlEditorApi/Domain/DopplerHtmlDocument.cs
@@ -38,6 +38,7 @@ public class DopplerHtmlDocument
 
     private readonly HtmlNode _headNode;
     private readonly HtmlNode _contentNode;
+    private readonly HtmlNode _rootNode;
 
     public DopplerHtmlDocument(string inputHtml)
     {
@@ -48,6 +49,8 @@ public class DopplerHtmlDocument
         _contentNode = _headNode == null ? htmlDocument.DocumentNode
             : htmlDocument.DocumentNode.SelectSingleNode("//body")
             ?? HtmlAgilityPackUtils.LoadHtml(inputHtml.Replace(_headNode.OuterHtml, string.Empty)).DocumentNode;
+
+        _rootNode = _contentNode.OwnerDocument.DocumentNode;
     }
 
     public string GetDopplerContent()
@@ -83,7 +86,7 @@ public class DopplerHtmlDocument
 
     public void RemoveHarmfulTags()
     {
-        var harmfulTags = _contentNode.SelectNodes(@"//script|//embed|//iframe|//meta[contains(@http-equiv,'refresh')]").EmptyIfNull();
+        var harmfulTags = _rootNode.SelectNodes(@"//script|//embed|//iframe|//meta[contains(@http-equiv,'refresh')]").EmptyIfNull();
         foreach (var tag in harmfulTags)
         {
             tag.Remove();


### PR DESCRIPTION
`_contentNode.SelectNodes()` was returning nodes that were not descendants of `_contentNode` but of `_headNode`. It is weird, but maybe it is expected in _HtmlAgilityPack_.

Anyway, to make it clear, I added a `_rootNode` that includes `_contentNode` and, if it exists, `_headNode`.

I have also done some improvements in the tests to confirm that the element case was not being taken into account in RemoveHarmfulTags.