### PR TITLE
DE-477 - Remove event attributes

### DIFF
--- a/Doppler.HtmlEditorApi.Test/Domain/DopplerHtmlDocumentTest.cs
+++ b/Doppler.HtmlEditorApi.Test/Domain/DopplerHtmlDocumentTest.cs
@@ -472,6 +472,69 @@ shareArticle?mini=true&amp;url=https%3a%2f%2fvp.mydplr.com%2f123&amp;title=Prueb
         AssertHelper.EqualIgnoringMeaninglessSpaces(expectedHead, headContent);
     }
 
+    [Theory]
+    [InlineDataAttribute(
+        @"
+<article>
+    <h1>Title</h1>
+    <p onclick=""alert('malicious message')"">This is a paragraph.</p>
+    <p OnMouseOver=""window.href='https://malicious.site'"">This is another paragraph.</p>
+    <button onclick=""alert('malicious message')"">This is a button.</button>
+</article>",
+        @"
+<article>
+    <h1>Title</h1>
+    <p>This is a paragraph.</p>
+    <p>This is another paragraph.</p>
+    <button>This is a button.</button>
+</article>")]
+    public void RemoveEventAttributes_should_remove_eventAttributes_from_body(string input, string expectedBody)
+    {
+        // Arrange
+        var htmlDocument = new DopplerHtmlDocument(input);
+
+        // Act
+        htmlDocument.RemoveEventAttributes();
+
+        // Assert
+        var content = htmlDocument.GetDopplerContent();
+        AssertHelper.EqualIgnoringMeaninglessSpaces(expectedBody, content);
+    }
+
+    [Theory]
+    [InlineDataAttribute(
+        @"
+<html>
+<head>
+    <title>Hello safety!</title>
+    <meta name=""copyright"" content=""© 2022 FromDoppler"">
+    <p onclick=""alert('malicious message')"">This is a paragraph.</p>
+    <p OnMouseOver=""window.href='https://malicious.site'"">This is another paragraph.</p>
+    <meta http-equiv=""Content-Type"" content=""text/html; charset=UTF-8"">
+</head>
+<body>
+    <p>This is a paragraph</p>
+</body>
+</html>",
+        @"
+<title>Hello safety!</title>
+<meta name=""copyright"" content=""© 2022 FromDoppler"">
+<p>This is a paragraph.</p>
+<p>This is another paragraph.</p>
+<meta http-equiv=""Content-Type"" content=""text/html; charset=UTF-8"">")]
+    public void RemoveEventAttributes_should_remove_eventAttributes_from_head(string input, string expectedHead)
+    {
+        // Arrange
+        var htmlDocument = new DopplerHtmlDocument(input);
+
+        // Act
+        htmlDocument.RemoveEventAttributes();
+
+        // Assert
+        var headContent = htmlDocument.GetHeadContent();
+        AssertHelper.EqualIgnoringMeaninglessSpaces(expectedHead, headContent);
+    }
+
     private string CreateTestContentWithLink(string href)
         => $@"<div>
     <a href=""{href}"">Link</a>

--- a/Doppler.HtmlEditorApi/Controllers/CampaignsController.cs
+++ b/Doppler.HtmlEditorApi/Controllers/CampaignsController.cs
@@ -97,6 +97,7 @@ namespace Doppler.HtmlEditorApi.Controllers
 
             var htmlDocument = new DopplerHtmlDocument(campaignContent.htmlContent);
             htmlDocument.RemoveHarmfulTags();
+            htmlDocument.RemoveEventAttributes();
             htmlDocument.ReplaceFieldNameTagsByFieldIdTags(dopplerFieldsProcessor.GetFieldIdOrNull);
             htmlDocument.RemoveUnknownFieldIdTags(dopplerFieldsProcessor.FieldIdExist);
             htmlDocument.SanitizeTrackableLinks();

--- a/Doppler.HtmlEditorApi/Domain/DopplerHtmlDocument.cs
+++ b/Doppler.HtmlEditorApi/Domain/DopplerHtmlDocument.cs
@@ -93,6 +93,18 @@ public class DopplerHtmlDocument
         }
     }
 
+    public void RemoveEventAttributes()
+    {
+        var eventAttributes = _rootNode.Descendants()
+            .SelectMany(x => x.Attributes.Where(x => x.Name.StartsWith("on", StringComparison.OrdinalIgnoreCase)))
+            .ToList();
+
+        foreach (var attribute in eventAttributes)
+        {
+            attribute.Remove();
+        }
+    }
+
     public void ReplaceFieldNameTagsByFieldIdTags(Func<string, int?> getFieldIdOrNullFunc)
     {
         _contentNode.TraverseAndReplaceTextsAndAttributeValues(text => FIELD_NAME_TAG_REGEX.Replace(


### PR DESCRIPTION
Hi team, 

I think that I am concluding with the user story with this PR. Feel free to only pay attention to the last commit because the other commits are shared with #92.

It searches for all attributes with names starting with `on` and removes them from the document.

Could you review it?