### PR TITLE
[DE-605] crear campaña a partir de un unlayer template

### DIFF
--- a/Doppler.HtmlEditorApi/ApiModels/Template.cs
+++ b/Doppler.HtmlEditorApi/ApiModels/Template.cs
@@ -2,4 +2,4 @@ using System.Text.Json;
 
 namespace Doppler.HtmlEditorApi.ApiModels;
 
-public record Template(ContentType type, string name, JsonElement? meta, string htmlContent, string previewImage) : Content(type, meta, htmlContent, previewImage);
+public record Template(string htmlCode, JsonElement? meta, string previewImage);

--- a/Doppler.HtmlEditorApi/Domain/TemplateData.cs
+++ b/Doppler.HtmlEditorApi/Domain/TemplateData.cs
@@ -1,0 +1,24 @@
+namespace Doppler.HtmlEditorApi.Domain;
+
+public abstract record TemplateData(
+    string HtmlCode,
+    string Meta,
+    string PreviewImage,
+    int EditorType,
+    bool IsPublic)
+{ }
+
+public sealed record UnlayerTemplateData(
+    string HtmlCode,
+    string Meta,
+    string PreviewImage,
+    int EditorType,
+    bool IsPublic)
+    : TemplateData(HtmlCode, Meta, PreviewImage, EditorType, IsPublic);
+
+public sealed record UnknownTemplateData(
+    string HtmlCode,
+    string PreviewImage,
+    int EditorType,
+    bool IsPublic)
+    : TemplateData(HtmlCode, null, PreviewImage, EditorType, IsPublic);

--- a/Doppler.HtmlEditorApi/Repositories.DopplerDb/DopplerDbServiceCollectionExtensions.cs
+++ b/Doppler.HtmlEditorApi/Repositories.DopplerDb/DopplerDbServiceCollectionExtensions.cs
@@ -8,5 +8,6 @@ public static class DopplerDbServiceCollectionExtensions
     public static IServiceCollection AddDopplerDbRepositories(this IServiceCollection services)
         => services
             .AddScoped<ICampaignContentRepository, DapperCampaignContentRepository>()
+            .AddScoped<ITemplateRepository, DapperTemplateRepository>()
             .AddScoped<IFieldsRepository, DapperFieldsRepository>();
 }

--- a/Doppler.HtmlEditorApi/Repositories.DopplerDb/DopplerTemplateRepository.cs
+++ b/Doppler.HtmlEditorApi/Repositories.DopplerDb/DopplerTemplateRepository.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Doppler.HtmlEditorApi.DataAccess;
+using Doppler.HtmlEditorApi.Domain;
+using Doppler.HtmlEditorApi.Repositories.DopplerDb.Queries;
+
+namespace Doppler.HtmlEditorApi.Repositories.DopplerDb;
+
+public class DapperTemplateRepository : ITemplateRepository
+{
+    private const int EditorTypeUnlayer = 5;
+
+    private readonly IDbContext _dbContext;
+    public DapperTemplateRepository(IDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<TemplateData> GetTemplate(string accountName, int templateId)
+    {
+        var queryResult = await _dbContext.ExecuteAsync(new GetTemplateByIdWithStatusDbQuery(
+            IdTemplate: templateId,
+            AccountName: accountName
+        ));
+
+        return queryResult == null ? null
+            : (queryResult.IsPublic && queryResult.EditorType == EditorTypeUnlayer) ? new UnlayerTemplateData(
+                HtmlCode: queryResult.HtmlCode,
+                Meta: queryResult.Meta,
+                PreviewImage: queryResult.PreviewImage,
+                EditorType: queryResult.EditorType,
+                IsPublic: queryResult.IsPublic)
+            // TODO: improve flow for content when is from other editor type
+            : new UnknownTemplateData(
+                HtmlCode: queryResult.HtmlCode,
+                PreviewImage: queryResult.PreviewImage,
+                EditorType: queryResult.EditorType,
+                IsPublic: queryResult.IsPublic);
+    }
+}

--- a/Doppler.HtmlEditorApi/Repositories.DopplerDb/Queries/GetTemplateByIdWithStatusDbQuery.cs
+++ b/Doppler.HtmlEditorApi/Repositories.DopplerDb/Queries/GetTemplateByIdWithStatusDbQuery.cs
@@ -1,0 +1,34 @@
+using Doppler.HtmlEditorApi.DataAccess;
+
+namespace Doppler.HtmlEditorApi.Repositories.DopplerDb.Queries;
+
+public record GetTemplateByIdWithStatusDbQuery(
+    int IdTemplate,
+    string AccountName
+) : ISingleItemDbQuery<GetTemplateByIdWithStatusDbQuery.Result>
+{
+    public string GenerateSqlQuery() => @"
+SELECT
+    @IdTemplate as IdTemplate,
+    CAST (CASE WHEN Tp.IdUser IS NULL THEN 1 ELSE 0 END AS BIT) AS IsPublic,
+    Tp.EditorType,
+    Tp.HtmlCode,
+    Tp.Meta,
+    Tp.PreviewImage
+FROM [Template] Tp
+LEFT JOIN [User] u ON
+    u.IdUser = Tp.IdUser
+WHERE
+    Tp.IdTemplate = @IdTemplate
+    AND (u.Email = @AccountName OR Tp.IdUser IS NULL)
+    AND Tp.Active = 1";
+
+    public class Result
+    {
+        public bool IsPublic { get; init; }
+        public int EditorType { get; init; }
+        public string HtmlCode { get; init; }
+        public string Meta { get; init; }
+        public string PreviewImage { get; init; }
+    }
+}

--- a/Doppler.HtmlEditorApi/Repositories/ITemplateRepository.cs
+++ b/Doppler.HtmlEditorApi/Repositories/ITemplateRepository.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Doppler.HtmlEditorApi.Domain;
+
+namespace Doppler.HtmlEditorApi.Repositories;
+
+public interface ITemplateRepository
+{
+    Task<TemplateData> GetTemplate(string accountName, int templateId);
+}

--- a/demo.http
+++ b/demo.http
@@ -12,6 +12,11 @@ GET {{base}}/accounts/amoschini@makingsense.com/campaigns/18313525/content
 Authorization: Bearer {{Token}}
 
 ###
+POST {{base}}/accounts/cromero@makingsense.com/campaigns/36358896/content/from-template/17461
+Content-Type: application/json
+Authorization: Bearer {{Token}}
+
+###
 PUT {{base}}/accounts/amoschini@makingsense.com/campaigns/18313525/content
 Content-Type: application/json
 Authorization: Bearer {{Token}}


### PR DESCRIPTION
Como parte de la tarea [DE-574](https://makingsense.atlassian.net/browse/DE-574) se agrega el endpoint _/accounts/{username}/campaigns/{campaignId}/content/from-template/{templateId}_ para la creación del contenido de una campaña a partir de un template publico/privado.

_Restricciones de la funcionalidad:_
- No se pueden crear contenido con templates inactivos
- No se puede crear contenido con templates privados que no pertenezcan al usuario

Tarea: [[DE-605]](https://makingsense.atlassian.net/browse/DE-605)

[DE-605]: https://makingsense.atlassian.net/browse/DE-605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ