### PR TITLE
Renombrado los repositorios con prefijo Dapper

### DIFF
--- a/Doppler.HtmlEditorApi.Test/Repositories.DopplerDb/DopplerCampaignContentRepositoryTest.cs
+++ b/Doppler.HtmlEditorApi.Test/Repositories.DopplerDb/DopplerCampaignContentRepositoryTest.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace Doppler.HtmlEditorApi.Repositories.DopplerDb;
 
-public class DapperCampaignContentRepositoryTest : IClassFixture<WebApplicationFactory<Startup>>
+public class DopplerCampaignContentRepositoryTest : IClassFixture<WebApplicationFactory<Startup>>
 {
     [Theory]
     [InlineData(null, false)]
@@ -46,7 +46,7 @@ public class DapperCampaignContentRepositoryTest : IClassFixture<WebApplicationF
                 EditorType = 5,
                 Status = dopplerCampaignStatus
             });
-        var repository = new DapperCampaignContentRepository(dbContextMock.Object);
+        var repository = new DopplerCampaignContentRepository(dbContextMock.Object);
 
         var campaignState = await repository.GetCampaignState(It.IsAny<string>(), It.IsAny<int>());
         Assert.Equal(expectedIsWritable, campaignState.IsWritable);

--- a/Doppler.HtmlEditorApi/Repositories.DopplerDb/DopplerCampaignContentRepository.cs
+++ b/Doppler.HtmlEditorApi/Repositories.DopplerDb/DopplerCampaignContentRepository.cs
@@ -8,7 +8,7 @@ using Doppler.HtmlEditorApi.Repositories.DopplerDb.Queries;
 
 namespace Doppler.HtmlEditorApi.Repositories.DopplerDb;
 
-public class DapperCampaignContentRepository : ICampaignContentRepository
+public class DopplerCampaignContentRepository : ICampaignContentRepository
 {
     private const int EditorTypeMSEditor = 4;
     private const int EditorTypeUnlayer = 5;
@@ -19,7 +19,7 @@ public class DapperCampaignContentRepository : ICampaignContentRepository
     private static int? DopplerCampaignTypeClassic => null;
 
     private readonly IDbContext _dbContext;
-    public DapperCampaignContentRepository(IDbContext dbContext)
+    public DopplerCampaignContentRepository(IDbContext dbContext)
     {
         _dbContext = dbContext;
     }

--- a/Doppler.HtmlEditorApi/Repositories.DopplerDb/DopplerDbServiceCollectionExtensions.cs
+++ b/Doppler.HtmlEditorApi/Repositories.DopplerDb/DopplerDbServiceCollectionExtensions.cs
@@ -7,7 +7,7 @@ public static class DopplerDbServiceCollectionExtensions
 {
     public static IServiceCollection AddDopplerDbRepositories(this IServiceCollection services)
         => services
-            .AddScoped<ICampaignContentRepository, DapperCampaignContentRepository>()
-            .AddScoped<ITemplateRepository, DapperTemplateRepository>()
-            .AddScoped<IFieldsRepository, DapperFieldsRepository>();
+            .AddScoped<ICampaignContentRepository, DopplerCampaignContentRepository>()
+            .AddScoped<ITemplateRepository, DopplerTemplateRepository>()
+            .AddScoped<IFieldsRepository, DopplerFieldsRepository>();
 }

--- a/Doppler.HtmlEditorApi/Repositories.DopplerDb/DopplerFieldsRepository.cs
+++ b/Doppler.HtmlEditorApi/Repositories.DopplerDb/DopplerFieldsRepository.cs
@@ -7,10 +7,10 @@ using Doppler.HtmlEditorApi.Repositories.DopplerDb.Queries;
 
 namespace Doppler.HtmlEditorApi.Repositories.DopplerDb;
 
-public class DapperFieldsRepository : IFieldsRepository
+public class DopplerFieldsRepository : IFieldsRepository
 {
     private readonly IDbContext _dbContext;
-    public DapperFieldsRepository(IDbContext dbContext)
+    public DopplerFieldsRepository(IDbContext dbContext)
     {
         _dbContext = dbContext;
     }

--- a/Doppler.HtmlEditorApi/Repositories.DopplerDb/DopplerTemplateRepository.cs
+++ b/Doppler.HtmlEditorApi/Repositories.DopplerDb/DopplerTemplateRepository.cs
@@ -8,12 +8,12 @@ using Doppler.HtmlEditorApi.Repositories.DopplerDb.Queries;
 
 namespace Doppler.HtmlEditorApi.Repositories.DopplerDb;
 
-public class DapperTemplateRepository : ITemplateRepository
+public class DopplerTemplateRepository : ITemplateRepository
 {
     private const int EditorTypeUnlayer = 5;
 
     private readonly IDbContext _dbContext;
-    public DapperTemplateRepository(IDbContext dbContext)
+    public DopplerTemplateRepository(IDbContext dbContext)
     {
         _dbContext = dbContext;
     }


### PR DESCRIPTION
Para mantener la consistencia con la [arquitectura planteada](https://raw.githubusercontent.com/FromDoppler/doppler-html-editor-api/main/docs/project-architecture.svg) se renombro las clases con prefijo Dapper por Doppler según corresponde.