### PR TITLE
[DE-683] almacenando idTemplate al guardar contenido de campaña

### DIFF
--- a/Doppler.HtmlEditorApi.Test/Repositories.DopplerDb/Queries/UpdateCampaignContentDbQueryTest.cs
+++ b/Doppler.HtmlEditorApi.Test/Repositories.DopplerDb/Queries/UpdateCampaignContentDbQueryTest.cs
@@ -31,7 +31,7 @@ SET
     Head = @Head,
     Meta = @Meta,
     EditorType = @EditorType
-    ,IdTemplate = @IdTemplate
+,IdTemplate = @IdTemplate
 WHERE IdCampaign = @IdCampaign";
 
         // Act
@@ -67,7 +67,7 @@ SET
     Head = @Head,
     Meta = @Meta,
     EditorType = @EditorType
-    
+
 WHERE IdCampaign = @IdCampaign";
 
         // Act

--- a/Doppler.HtmlEditorApi.Test/Repositories.DopplerDb/Queries/UpdateCampaignContentDbQueryTest.cs
+++ b/Doppler.HtmlEditorApi.Test/Repositories.DopplerDb/Queries/UpdateCampaignContentDbQueryTest.cs
@@ -1,0 +1,79 @@
+using Xunit;
+
+namespace Doppler.HtmlEditorApi.Repositories.DopplerDb.Queries;
+
+public class UpdateCampaignContentDbQueryTest
+{
+    [Fact]
+    public void UpdateCampaignContentQuery_should_update_when_idTemplate_has_value()
+    {
+        // Arrange
+        var idCampaign = 567;
+        var editorType = 5;
+        var content = "<html></html>";
+        var head = "<head></head>";
+        var meta = "{}";
+        var idTemplate = 123;
+
+        var dbQuery = new UpdateCampaignContentDbQuery(
+            IdCampaign: idCampaign,
+            EditorType: editorType,
+            Content: content,
+            Head: head,
+            Meta: meta,
+            IdTemplate: idTemplate
+        );
+
+        var expectedQuery = @$"
+UPDATE Content
+SET
+    Content = @Content,
+    Head = @Head,
+    Meta = @Meta,
+    EditorType = @EditorType
+    ,IdTemplate = @IdTemplate
+WHERE IdCampaign = @IdCampaign";
+
+        // Act
+        var sqlQuery = dbQuery.GenerateSqlQuery();
+
+        // Assert
+        Assert.Equal(expectedQuery, sqlQuery);
+    }
+
+    [Fact]
+    public void UpdateCampaignContentQuery_should_update_when_idTemplate_is_null()
+    {
+        // Arrange
+        var idCampaign = 567;
+        var editorType = 5;
+        var content = "<html></html>";
+        var head = "<head></head>";
+        var meta = "{}";
+
+        var dbQuery = new UpdateCampaignContentDbQuery(
+            IdCampaign: idCampaign,
+            EditorType: editorType,
+            Content: content,
+            Head: head,
+            Meta: meta,
+            IdTemplate: null
+        );
+
+        var expectedQuery = @$"
+UPDATE Content
+SET
+    Content = @Content,
+    Head = @Head,
+    Meta = @Meta,
+    EditorType = @EditorType
+    
+WHERE IdCampaign = @IdCampaign";
+
+        // Act
+        var sqlQuery = dbQuery.GenerateSqlQuery();
+
+        // Assert
+        Assert.Equal(expectedQuery, sqlQuery);
+    }
+}

--- a/Doppler.HtmlEditorApi.Test/Utils/IDbContextMockExtensions.cs
+++ b/Doppler.HtmlEditorApi.Test/Utils/IDbContextMockExtensions.cs
@@ -62,7 +62,8 @@ public static class IDbContextMockExtensions
         int idCampaign,
         string htmlContent,
         string meta,
-        int result)
+        int? idTemplate = null,
+        int result = 1)
     {
         dbContextMock.Setup(x => x.ExecuteAsync(
             It.Is<IExecutableDbQuery>(q =>
@@ -71,12 +72,14 @@ public static class IDbContextMockExtensions
                     q.Is<InsertCampaignContentDbQuery>(x =>
                     x.IdCampaign == idCampaign
                     && x.Content == htmlContent
-                    && x.Meta == meta)
+                    && x.Meta == meta
+                    && x.IdTemplate == idTemplate)
                     ||
                     q.Is<UpdateCampaignContentDbQuery>(x =>
                     x.IdCampaign == idCampaign
                     && x.Content == htmlContent
-                    && x.Meta == meta)
+                    && x.Meta == meta
+                    && x.IdTemplate == idTemplate)
                 ))))
         .ReturnsAsync(result);
     }

--- a/Doppler.HtmlEditorApi.Test/http/accounts/_/campaings/_/content/GetCampaignTest.cs
+++ b/Doppler.HtmlEditorApi.Test/http/accounts/_/campaings/_/content/GetCampaignTest.cs
@@ -136,7 +136,8 @@ public class GetCampaignTest : IClassFixture<WebApplicationFactory<Startup>>
             }),
             HtmlContent: "<html></html>",
             HtmlHead: null,
-            PreviewImage: null);
+            PreviewImage: null,
+            IdTemplate: null);
 
         var repositoryMock = new Mock<ICampaignContentRepository>();
 

--- a/Doppler.HtmlEditorApi/Controllers/CampaignsController.cs
+++ b/Doppler.HtmlEditorApi/Controllers/CampaignsController.cs
@@ -116,11 +116,13 @@ namespace Doppler.HtmlEditorApi.Controllers
                     HtmlContent: content,
                     HtmlHead: head,
                     Meta: campaignContent.meta.ToString(),
-                    PreviewImage: campaignContent.previewImage),
+                    PreviewImage: campaignContent.previewImage,
+                    IdTemplate: null),
                 ContentType.html => new HtmlContentData(
                     HtmlContent: content,
                     HtmlHead: head,
-                    PreviewImage: campaignContent.previewImage),
+                    PreviewImage: campaignContent.previewImage,
+                    IdTemplate: null),
                 _ => throw new NotImplementedException($"Unsupported campaign content type {campaignContent.type:G}")
             };
 
@@ -170,7 +172,8 @@ namespace Doppler.HtmlEditorApi.Controllers
                     HtmlContent: content,
                     HtmlHead: head,
                     Meta: unlayerTemplateData.Meta,
-                    PreviewImage: unlayerTemplateData.PreviewImage);
+                    PreviewImage: unlayerTemplateData.PreviewImage,
+                    IdTemplate: templateId);
 
             // TODO: Save templateId reference with the content
             await SaveCampaignContent(baseHtmlContent, fieldIds, trackableUrls, campaignState);

--- a/Doppler.HtmlEditorApi/Domain/ContentData.cs
+++ b/Doppler.HtmlEditorApi/Domain/ContentData.cs
@@ -22,18 +22,21 @@ public sealed record MSEditorContentData(
 public abstract record BaseHtmlContentData(
     string HtmlContent,
     string HtmlHead,
-    string PreviewImage)
+    string PreviewImage,
+    int? IdTemplate)
     : ContentData();
 
 public sealed record HtmlContentData(
     string HtmlContent,
     string HtmlHead,
-    string PreviewImage)
-    : BaseHtmlContentData(HtmlContent, HtmlHead, PreviewImage);
+    string PreviewImage,
+    int? IdTemplate)
+    : BaseHtmlContentData(HtmlContent, HtmlHead, PreviewImage, IdTemplate);
 
 public sealed record UnlayerContentData(
     string HtmlContent,
     string HtmlHead,
     string Meta,
-    string PreviewImage)
-    : BaseHtmlContentData(HtmlContent, HtmlHead, PreviewImage);
+    string PreviewImage,
+    int? IdTemplate)
+    : BaseHtmlContentData(HtmlContent, HtmlHead, PreviewImage, IdTemplate);

--- a/Doppler.HtmlEditorApi/Repositories.DopplerDb/DopplerCampaignContentRepository.cs
+++ b/Doppler.HtmlEditorApi/Repositories.DopplerDb/DopplerCampaignContentRepository.cs
@@ -38,11 +38,13 @@ public class DopplerCampaignContentRepository : ICampaignContentRepository
                 HtmlContent: queryResult.Content,
                 HtmlHead: queryResult.Head,
                 Meta: queryResult.Meta,
-                PreviewImage: queryResult.PreviewImage)
+                PreviewImage: queryResult.PreviewImage,
+                IdTemplate: queryResult.IdTemplate)
             : queryResult.EditorType == null ? new HtmlContentData(
                 HtmlContent: queryResult.Content,
                 HtmlHead: queryResult.Head,
-                PreviewImage: queryResult.PreviewImage)
+                PreviewImage: queryResult.PreviewImage,
+                IdTemplate: queryResult.IdTemplate)
             : new UnknownContentData(
                 CampaignId: queryResult.IdCampaign,
                 Content: queryResult.Content,
@@ -101,14 +103,16 @@ public class DopplerCampaignContentRepository : ICampaignContentRepository
                 Content: unlayerContentData.HtmlContent,
                 Head: unlayerContentData.HtmlHead,
                 Meta: unlayerContentData.Meta,
-                EditorType: EditorTypeUnlayer
+                EditorType: EditorTypeUnlayer,
+                IdTemplate: unlayerContentData.IdTemplate
             ),
             HtmlContentData htmlContentData => new InsertCampaignContentDbQuery(
                 IdCampaign: campaignId,
                 Content: htmlContentData.HtmlContent,
                 Head: htmlContentData.HtmlHead,
                 Meta: null,
-                EditorType: null
+                EditorType: null,
+                IdTemplate: htmlContentData.IdTemplate
             ),
             // TODO: test this scenario
             // Probably a unit test will be necessary

--- a/Doppler.HtmlEditorApi/Repositories.DopplerDb/DopplerCampaignContentRepository.cs
+++ b/Doppler.HtmlEditorApi/Repositories.DopplerDb/DopplerCampaignContentRepository.cs
@@ -131,14 +131,16 @@ public class DopplerCampaignContentRepository : ICampaignContentRepository
                 Content: unlayerContentData.HtmlContent,
                 Head: unlayerContentData.HtmlHead,
                 Meta: unlayerContentData.Meta,
-                EditorType: EditorTypeUnlayer
+                EditorType: EditorTypeUnlayer,
+                IdTemplate: unlayerContentData.IdTemplate
             ),
             HtmlContentData htmlContentData => new UpdateCampaignContentDbQuery(
                 IdCampaign: campaignId,
                 Content: htmlContentData.HtmlContent,
                 Head: htmlContentData.HtmlHead,
                 Meta: null,
-                EditorType: null
+                EditorType: null,
+                IdTemplate: htmlContentData.IdTemplate
             ),
             // TODO: test this scenario
             // Probably a unit test will be necessary

--- a/Doppler.HtmlEditorApi/Repositories.DopplerDb/Queries/FirstOrDefaultContentWithCampaignStatusDbQuery.cs
+++ b/Doppler.HtmlEditorApi/Repositories.DopplerDb/Queries/FirstOrDefaultContentWithCampaignStatusDbQuery.cs
@@ -16,6 +16,7 @@ SELECT
     co.Content,
     co.Head,
     co.Meta,
+    co.IdTemplate,
     ca.PreviewImage
 FROM [User] u
 LEFT JOIN [Campaign] ca ON
@@ -36,5 +37,6 @@ WHERE
         public string Head { get; init; }
         public string Meta { get; init; }
         public string PreviewImage { get; init; }
+        public int? IdTemplate { get; init; }
     }
 }

--- a/Doppler.HtmlEditorApi/Repositories.DopplerDb/Queries/InsertCampaignContentDbQuery.cs
+++ b/Doppler.HtmlEditorApi/Repositories.DopplerDb/Queries/InsertCampaignContentDbQuery.cs
@@ -7,7 +7,8 @@ public record InsertCampaignContentDbQuery(
     int? EditorType,
     string Content,
     string Head,
-    string Meta
+    string Meta,
+    int? IdTemplate
 ) : IExecutableDbQuery
 {
     public string GenerateSqlQuery() => @"
@@ -16,12 +17,14 @@ INSERT INTO Content (
     Content,
     Head,
     Meta,
-    EditorType
+    EditorType,
+    IdTemplate
 ) VALUES (
     @IdCampaign,
     @Content,
     @Head,
     @Meta,
-    @EditorType
+    @EditorType,
+    @IdTemplate
 )";
 }

--- a/Doppler.HtmlEditorApi/Repositories.DopplerDb/Queries/UpdateCampaignContentDbQuery.cs
+++ b/Doppler.HtmlEditorApi/Repositories.DopplerDb/Queries/UpdateCampaignContentDbQuery.cs
@@ -18,6 +18,6 @@ SET
     Head = @Head,
     Meta = @Meta,
     EditorType = @EditorType
-    {(IdTemplate.HasValue ? ",IdTemplate = @IdTemplate" : "")}
+{(IdTemplate.HasValue ? ",IdTemplate = @IdTemplate" : "")}
 WHERE IdCampaign = @IdCampaign";
 }

--- a/Doppler.HtmlEditorApi/Repositories.DopplerDb/Queries/UpdateCampaignContentDbQuery.cs
+++ b/Doppler.HtmlEditorApi/Repositories.DopplerDb/Queries/UpdateCampaignContentDbQuery.cs
@@ -7,15 +7,17 @@ public record UpdateCampaignContentDbQuery(
     int? EditorType,
     string Content,
     string Head,
-    string Meta
+    string Meta,
+    int? IdTemplate
 ) : IExecutableDbQuery
 {
-    public string GenerateSqlQuery() => @"
+    public string GenerateSqlQuery() => @$"
 UPDATE Content
 SET
     Content = @Content,
     Head = @Head,
     Meta = @Meta,
     EditorType = @EditorType
+    {(IdTemplate.HasValue ? ",IdTemplate = @IdTemplate" : "")}
 WHERE IdCampaign = @IdCampaign";
 }


### PR DESCRIPTION
Ahora se almacena el IdTemplate cuando se crea un contenido desde una plantilla

[[DE-683]](https://makingsense.atlassian.net/browse/DE-683)

[DE-683]: https://makingsense.atlassian.net/browse/DE-683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ