### PR TITLE
fix: instruct clients to cache preflight requests

### DIFF
--- a/Doppler.HtmlEditorApi/Startup.cs
+++ b/Doppler.HtmlEditorApi/Startup.cs
@@ -84,6 +84,7 @@ namespace Doppler.HtmlEditorApi
 
             app.UseCors(policy => policy
                 .SetIsOriginAllowed(isOriginAllowed: _ => true)
+                .SetPreflightMaxAge(TimeSpan.FromHours(24))
                 .AllowAnyHeader()
                 .AllowAnyMethod()
                 .AllowCredentials());


### PR DESCRIPTION
Hi team!

As you know, we are using different sub-domains for our APIs and Frontends. Many times, it forces the browser to use preflight requests to allow CORS.

I think that this simple change will reduce the number of preflight requests done, improving the client performance and avoiding unnecessary work on the server.

More details in https://httptoolkit.tech/blog/cache-your-cors/#cors-caching-for-browsers

We can apply the same improvements in other APIs if it works fine.