### PR TITLE
CORS cache instruction for CDNs

### DIFF
--- a/Doppler.HtmlEditorApi/DopplerCors/DopplerCorsMiddlewareExtensions.cs
+++ b/Doppler.HtmlEditorApi/DopplerCors/DopplerCorsMiddlewareExtensions.cs
@@ -1,0 +1,28 @@
+using System;
+using Microsoft.AspNetCore.Cors.Infrastructure;
+
+namespace Microsoft.AspNetCore.Builder;
+
+public static class DopplerCorsMiddlewareExtensions
+{
+    public static IApplicationBuilder UseDopplerCors(this IApplicationBuilder app)
+    {
+        app.Use(async (context, next) =>
+        {
+            if (context.Request.Method == "OPTIONS")
+            {
+                context.Response.Headers.CacheControl = "public, max-age=86400";
+            }
+            await next();
+        });
+
+        app.UseCors(policy => policy
+            .SetIsOriginAllowed(isOriginAllowed: _ => true)
+            .SetPreflightMaxAge(TimeSpan.FromHours(24))
+            .AllowAnyHeader()
+            .AllowAnyMethod()
+            .AllowCredentials());
+
+        return app;
+    }
+}

--- a/Doppler.HtmlEditorApi/Startup.cs
+++ b/Doppler.HtmlEditorApi/Startup.cs
@@ -82,6 +82,15 @@ namespace Doppler.HtmlEditorApi
 
             app.UseRouting();
 
+            app.Use(async (context, next) =>
+            {
+                if (context.Request.Method == "OPTIONS")
+                {
+                    context.Response.Headers.CacheControl = "public, max-age=86400";
+                }
+                await next();
+            });
+
             app.UseCors(policy => policy
                 .SetIsOriginAllowed(isOriginAllowed: _ => true)
                 .SetPreflightMaxAge(TimeSpan.FromHours(24))

--- a/Doppler.HtmlEditorApi/Startup.cs
+++ b/Doppler.HtmlEditorApi/Startup.cs
@@ -82,21 +82,7 @@ namespace Doppler.HtmlEditorApi
 
             app.UseRouting();
 
-            app.Use(async (context, next) =>
-            {
-                if (context.Request.Method == "OPTIONS")
-                {
-                    context.Response.Headers.CacheControl = "public, max-age=86400";
-                }
-                await next();
-            });
-
-            app.UseCors(policy => policy
-                .SetIsOriginAllowed(isOriginAllowed: _ => true)
-                .SetPreflightMaxAge(TimeSpan.FromHours(24))
-                .AllowAnyHeader()
-                .AllowAnyMethod()
-                .AllowCredentials());
+            app.UseDopplerCors();
 
             app.UseAuthorization();
 


### PR DESCRIPTION
Based on <https://httptoolkit.tech/blog/cache-your-cors/#cors-caching-for-cdns>

I know that this code is not so elegant, but at least it is small and it is all in a single place.