### PR TITLE
Split campaign and content

### DIFF
--- a/Doppler.HtmlEditorApi.Test/Repositories.DopplerDb/DopplerTemplateRepositoryTest.cs
+++ b/Doppler.HtmlEditorApi.Test/Repositories.DopplerDb/DopplerTemplateRepositoryTest.cs
@@ -32,12 +32,12 @@ public class DopplerTemplateRepositoryTest : IClassFixture<WebApplicationFactory
             });
         var repository = new DopplerTemplateRepository(dbContextMock.Object);
 
-        var templateContentData = await repository.GetTemplate(It.IsAny<string>(), It.IsAny<int>());
-        var unlayerTemplateContentData = Assert.IsType<UnlayerTemplateContentData>(templateContentData);
+        var templateModel = await repository.GetTemplate(It.IsAny<string>(), It.IsAny<int>());
+        var unlayerTemplateContentData = Assert.IsType<UnlayerTemplateContentData>(templateModel.Content);
         Assert.NotNull(unlayerTemplateContentData.HtmlComplete);
         Assert.NotNull(unlayerTemplateContentData.Meta);
-        Assert.NotNull(unlayerTemplateContentData.PreviewImage);
-        Assert.Equal(isPublicExpected, unlayerTemplateContentData.IsPublic);
+        Assert.NotNull(templateModel.PreviewImage);
+        Assert.Equal(isPublicExpected, templateModel.IsPublic);
         dbContextMock.VerifyAll();
     }
 
@@ -61,10 +61,10 @@ public class DopplerTemplateRepositoryTest : IClassFixture<WebApplicationFactory
             });
         var repository = new DopplerTemplateRepository(dbContextMock.Object);
 
-        var templateContentData = await repository.GetTemplate(It.IsAny<string>(), It.IsAny<int>());
-        var uknownTemplateContentData = Assert.IsType<UnknownTemplateContentData>(templateContentData);
-        Assert.Equal(isPublicExpected, uknownTemplateContentData.IsPublic);
-        Assert.Equal(_msEditorType, uknownTemplateContentData.EditorType);
+        var templateModel = await repository.GetTemplate(It.IsAny<string>(), It.IsAny<int>());
+        var unknownTemplateContentData = Assert.IsType<UnknownTemplateContentData>(templateModel.Content);
+        Assert.Equal(isPublicExpected, templateModel.IsPublic);
+        Assert.Equal(_msEditorType, unknownTemplateContentData.EditorType);
         dbContextMock.VerifyAll();
     }
 }

--- a/Doppler.HtmlEditorApi.Test/http/accounts/_/campaings/_/content/GetCampaignTest.cs
+++ b/Doppler.HtmlEditorApi.Test/http/accounts/_/campaings/_/content/GetCampaignTest.cs
@@ -102,12 +102,12 @@ public class GetCampaignTest : IClassFixture<WebApplicationFactory<Startup>>
     public async Task GET_campaign_should_accept_right_tokens_and_return_404_when_not_exist(string url, string token, string expectedAccountName, int expectedIdCampaign)
     {
         // Arrange
-        BaseHtmlCampaignContentData contentData = null;
+        CampaignModel campaignModel = null;
         var repositoryMock = new Mock<ICampaignContentRepository>();
 
         repositoryMock
             .Setup(x => x.GetCampaignModel(expectedAccountName, expectedIdCampaign))
-            .ReturnsAsync(contentData);
+            .ReturnsAsync(campaignModel);
 
         var client = _factory.CreateSutClient(
             serviceToOverride1: repositoryMock.Object,
@@ -136,15 +136,18 @@ public class GetCampaignTest : IClassFixture<WebApplicationFactory<Startup>>
             }),
             HtmlContent: "<html></html>",
             HtmlHead: null,
-            PreviewImage: null,
-            CampaignName: "unlayer_name",
             IdTemplate: null);
+        var campaignModel = new CampaignModel(
+            CampaignId: expectedIdCampaign,
+            Name: "unlayer_name",
+            PreviewImage: null,
+            Content: contentData);
 
         var repositoryMock = new Mock<ICampaignContentRepository>();
 
         repositoryMock
             .Setup(x => x.GetCampaignModel(expectedAccountName, expectedIdCampaign))
-            .ReturnsAsync(contentData);
+            .ReturnsAsync(campaignModel);
 
         var client = _factory.CreateSutClient(
             serviceToOverride1: repositoryMock.Object,
@@ -160,7 +163,6 @@ public class GetCampaignTest : IClassFixture<WebApplicationFactory<Startup>>
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.Matches("\"type\":\"unlayer\"", responseContent);
-        Assert.Matches("\"campaignName\":\"unlayer_name\"", responseContent);
         Assert.NotNull(contentModelResponse.meta);
         Assert.True(contentModelResponse.meta.Value.TryGetProperty("schemaVersion", out var resultSchemaVersionProp), "schemaVersion property is not present");
         Assert.Equal(JsonValueKind.Number, resultSchemaVersionProp.ValueKind);

--- a/Doppler.HtmlEditorApi.Test/http/accounts/_/campaings/_/content/from-template/_/CreateCampaignContentFromTemplateTest.cs
+++ b/Doppler.HtmlEditorApi.Test/http/accounts/_/campaings/_/content/from-template/_/CreateCampaignContentFromTemplateTest.cs
@@ -169,15 +169,15 @@ public class CreateCampaignContentFromTemplateTest : IClassFixture<WebApplicatio
     }
 
     [Theory]
-    [InlineData($"/accounts/{TestUsersData.EMAIL_TEST1}/campaigns/456/content/from-template/123", TestUsersData.TOKEN_TEST1_EXPIRE_20330518)]
-    public async Task POST_content_from_template_should_return_error_when_type_is_not_unlayer_editor(string url, string token)
+    [InlineData($"/accounts/{TestUsersData.EMAIL_TEST1}/campaigns/456/content/from-template/123", TestUsersData.TOKEN_TEST1_EXPIRE_20330518, 123)]
+    public async Task POST_content_from_template_should_return_error_when_type_is_not_unlayer_editor(string url, string token, int templateId)
     {
         // Arrange
         var templateContentData = new UnknownTemplateContentData(
             EditorType: 4);
 
         var templateModel = new TemplateModel(
-            TemplateId: 123,
+            TemplateId: templateId,
             IsPublic: true,
             PreviewImage: "",
             Name: "TemplateName",
@@ -191,7 +191,7 @@ public class CreateCampaignContentFromTemplateTest : IClassFixture<WebApplicatio
             .Setup(x => x.GetCampaignState(It.IsAny<string>(), It.IsAny<int>()))
             .ReturnsAsync(new ClassicCampaignState(456, true, null, CampaignStatus.Draft));
         templateRepositoryMock
-            .Setup(x => x.GetTemplate(It.IsAny<string>(), It.IsAny<int>()))
+            .Setup(x => x.GetTemplate(It.IsAny<string>(), templateId))
             .ReturnsAsync(templateModel);
 
         var client = _factory.CreateSutClient(

--- a/Doppler.HtmlEditorApi.Test/http/accounts/_/campaings/_/content/from-template/_/CreateCampaignContentFromTemplateTest.cs
+++ b/Doppler.HtmlEditorApi.Test/http/accounts/_/campaings/_/content/from-template/_/CreateCampaignContentFromTemplateTest.cs
@@ -129,13 +129,16 @@ public class CreateCampaignContentFromTemplateTest : IClassFixture<WebApplicatio
     public async Task POST_content_from_template_should_accept_right_tokens_and_return_Ok(string url, string token, string expectedAccountName, int templateId)
     {
         // Arrange
-        var templateContentData = new UnlayerTemplateContentData(
+        var contentData = new UnlayerTemplateContentData(
             HtmlComplete: "<html></html>",
-            Meta: "{}",
+            Meta: "{}");
+
+        var templateModel = new TemplateModel(
+            TemplateId: templateId,
+            IsPublic: true,
             PreviewImage: "",
-            Name: "",
-            EditorType: 5,
-            IsPublic: true
+            Name: "TemplateName",
+            Content: contentData
         );
 
         var templateRepositoryMock = new Mock<ITemplateRepository>();
@@ -146,7 +149,7 @@ public class CreateCampaignContentFromTemplateTest : IClassFixture<WebApplicatio
             .ReturnsAsync(new ClassicCampaignState(456, true, null, CampaignStatus.Draft));
         templateRepositoryMock
             .Setup(x => x.GetTemplate(expectedAccountName, templateId))
-            .ReturnsAsync(templateContentData);
+            .ReturnsAsync(templateModel);
 
         var client = _factory.CreateSutClient(
             templateRepositoryMock.Object,
@@ -171,8 +174,14 @@ public class CreateCampaignContentFromTemplateTest : IClassFixture<WebApplicatio
     {
         // Arrange
         var templateContentData = new UnknownTemplateContentData(
-            EditorType: 4,
-            IsPublic: true
+            EditorType: 4);
+
+        var templateModel = new TemplateModel(
+            TemplateId: 123,
+            IsPublic: true,
+            PreviewImage: "",
+            Name: "TemplateName",
+            Content: templateContentData
         );
 
         var templateRepositoryMock = new Mock<ITemplateRepository>();
@@ -183,7 +192,7 @@ public class CreateCampaignContentFromTemplateTest : IClassFixture<WebApplicatio
             .ReturnsAsync(new ClassicCampaignState(456, true, null, CampaignStatus.Draft));
         templateRepositoryMock
             .Setup(x => x.GetTemplate(It.IsAny<string>(), It.IsAny<int>()))
-            .ReturnsAsync(templateContentData);
+            .ReturnsAsync(templateModel);
 
         var client = _factory.CreateSutClient(
             templateRepositoryMock.Object,

--- a/Doppler.HtmlEditorApi/ApiModels/CampaignContent.cs
+++ b/Doppler.HtmlEditorApi/ApiModels/CampaignContent.cs
@@ -12,7 +12,8 @@ public record CampaignContent(
     [Required]
     string htmlContent,
     string previewImage,
-    string campaignName) : Content(type, meta, htmlContent, previewImage, campaignName), IValidatableObject
+    // Readonly
+    string campaignName) : Content(type, meta, htmlContent), IValidatableObject
 {
     private static readonly HashSet<ContentType> ValidContentTypes = new HashSet<ContentType>(Enum.GetValues<ContentType>());
 

--- a/Doppler.HtmlEditorApi/ApiModels/Content.cs
+++ b/Doppler.HtmlEditorApi/ApiModels/Content.cs
@@ -2,4 +2,4 @@ using System.Text.Json;
 
 namespace Doppler.HtmlEditorApi.ApiModels;
 
-public record Content(ContentType type, JsonElement? meta, string htmlContent, string previewImage, string campaignName);
+public abstract record Content(ContentType type, JsonElement? meta, string htmlContent);

--- a/Doppler.HtmlEditorApi/Controllers/CampaignsController.cs
+++ b/Doppler.HtmlEditorApi/Controllers/CampaignsController.cs
@@ -143,8 +143,8 @@ namespace Doppler.HtmlEditorApi.Controllers
                 return error;
             }
 
-            var templateContentData = await _templateRepository.GetTemplate(accountName, templateId);
-            if (templateContentData == null)
+            var templateModel = await _templateRepository.GetTemplate(accountName, templateId);
+            if (templateModel == null)
             {
                 return new NotFoundObjectResult(new ProblemDetails()
                 {
@@ -152,7 +152,9 @@ namespace Doppler.HtmlEditorApi.Controllers
                     Detail = $@"The template not exists or Inactive"
                 });
             }
-            if (templateContentData is not UnlayerTemplateContentData unlayerTemplateData)
+
+            var templateContentData = templateModel.Content;
+            if (templateContentData is not UnlayerTemplateContentData unlayerTemplateContentData)
             {
                 return new BadRequestObjectResult(new ProblemDetails()
                 {
@@ -161,7 +163,7 @@ namespace Doppler.HtmlEditorApi.Controllers
                 });
             }
 
-            var htmlDocument = await ExtractHtmlDomFromCampaignContent(accountName, unlayerTemplateData.HtmlComplete);
+            var htmlDocument = await ExtractHtmlDomFromCampaignContent(accountName, unlayerTemplateContentData.HtmlComplete);
             var head = htmlDocument.GetHeadContent();
             var content = htmlDocument.GetDopplerContent();
             var fieldIds = htmlDocument.GetFieldIds();
@@ -170,11 +172,11 @@ namespace Doppler.HtmlEditorApi.Controllers
             BaseHtmlCampaignContentData contentData = new UnlayerCampaignContentData(
                     HtmlContent: content,
                     HtmlHead: head,
-                    Meta: unlayerTemplateData.Meta,
+                    Meta: unlayerTemplateContentData.Meta,
                     IdTemplate: templateId);
 
             // TODO: Save templateId reference with the content
-            await SaveCampaignContent(contentData, fieldIds, trackableUrls, campaignState, unlayerTemplateData.PreviewImage);
+            await SaveCampaignContent(contentData, fieldIds, trackableUrls, campaignState, templateModel.PreviewImage);
 
             return new OkObjectResult($"La campaña '{campaignId}' del usuario '{accountName}' se guardó exitosamente ");
         }

--- a/Doppler.HtmlEditorApi/Controllers/CampaignsController.cs
+++ b/Doppler.HtmlEditorApi/Controllers/CampaignsController.cs
@@ -57,30 +57,34 @@ namespace Doppler.HtmlEditorApi.Controllers
         public async Task<ActionResult<CampaignContent>> GetCampaignContent(string accountName, int campaignId)
         {
             // TODO: Considere refactoring accountName validation
-            var contentData = await _campaignContentRepository.GetCampaignModel(accountName, campaignId);
+            var campaignModel = await _campaignContentRepository.GetCampaignModel(accountName, campaignId);
 
-            ActionResult<CampaignContent> result = contentData switch
+            if (campaignModel == null)
             {
-                null => new NotFoundObjectResult("Campaign not found or belongs to a different account"),
+                return new NotFoundObjectResult("Campaign not found or belongs to a different account");
+            }
+
+            ActionResult<CampaignContent> result = campaignModel.Content switch
+            {
                 EmptyCampaignContentData => new CampaignContent(
                     type: ContentType.unlayer,
                     meta: Utils.ParseAsJsonElement(EmptyUnlayerContentJson),
                     htmlContent: EmptyUnlayerContentHtml,
-                    previewImage: null,
-                    campaignName: null), // TODO: Take the name from campaign information
+                    previewImage: campaignModel.PreviewImage,
+                    campaignName: campaignModel.Name),
                 UnlayerCampaignContentData unlayerContent => new CampaignContent(
                     type: ContentType.unlayer,
                     meta: Utils.ParseAsJsonElement(unlayerContent.Meta),
                     htmlContent: GenerateHtmlContent(unlayerContent),
-                    previewImage: unlayerContent.PreviewImage,
-                    campaignName: unlayerContent.CampaignName),
+                    previewImage: campaignModel.PreviewImage,
+                    campaignName: campaignModel.Name),
                 BaseHtmlCampaignContentData htmlContent => new CampaignContent(
                     type: ContentType.html,
                     meta: null,
                     htmlContent: GenerateHtmlContent(htmlContent),
-                    previewImage: htmlContent.PreviewImage,
-                    campaignName: htmlContent.CampaignName),
-                _ => throw new NotImplementedException($"Unsupported campaign content type {contentData.GetType()}")
+                    previewImage: campaignModel.PreviewImage,
+                    campaignName: campaignModel.Name),
+                _ => throw new NotImplementedException($"Unsupported campaign content type {campaignModel.Content.GetType()}")
             };
 
             return result;
@@ -110,28 +114,21 @@ namespace Doppler.HtmlEditorApi.Controllers
             var fieldIds = htmlDocument.GetFieldIds();
             var trackableUrls = htmlDocument.GetTrackableUrls();
 
-            // TODO: Validate if it's possible to delete PreviewImage property from BaseHtmlContentData,
-            // because it's already in campaignContent
-            // See it on: https://github.com/FromDoppler/doppler-html-editor-api/pull/111#discussion_r870681998
             BaseHtmlCampaignContentData contentData = campaignContent.type switch
             {
                 ContentType.unlayer => new UnlayerCampaignContentData(
                     HtmlContent: content,
                     HtmlHead: head,
                     Meta: campaignContent.meta.ToString(),
-                    PreviewImage: campaignContent.previewImage,
-                    CampaignName: campaignContent.campaignName,
                     IdTemplate: null),
                 ContentType.html => new HtmlCampaignContentData(
                     HtmlContent: content,
                     HtmlHead: head,
-                    PreviewImage: campaignContent.previewImage,
-                    CampaignName: campaignContent.campaignName,
                     IdTemplate: null),
                 _ => throw new NotImplementedException($"Unsupported campaign content type {campaignContent.type:G}")
             };
 
-            await SaveCampaignContent(contentData, fieldIds, trackableUrls, campaignState);
+            await SaveCampaignContent(contentData, fieldIds, trackableUrls, campaignState, campaignContent.previewImage);
 
             return new OkObjectResult($"La campaña '{campaignId}' del usuario '{accountName}' se guardó exitosamente ");
         }
@@ -170,24 +167,19 @@ namespace Doppler.HtmlEditorApi.Controllers
             var fieldIds = htmlDocument.GetFieldIds();
             var trackableUrls = htmlDocument.GetTrackableUrls();
 
-            // TODO: Validate if it's possible to delete PreviewImage property from BaseHtmlContentData,
-            // because it's already in campaignContent
-            // See it on: https://github.com/FromDoppler/doppler-html-editor-api/pull/111#discussion_r870681998
             BaseHtmlCampaignContentData contentData = new UnlayerCampaignContentData(
                     HtmlContent: content,
                     HtmlHead: head,
                     Meta: unlayerTemplateData.Meta,
-                    PreviewImage: unlayerTemplateData.PreviewImage,
-                    CampaignName: unlayerTemplateData.Name,
                     IdTemplate: templateId);
 
             // TODO: Save templateId reference with the content
-            await SaveCampaignContent(contentData, fieldIds, trackableUrls, campaignState);
+            await SaveCampaignContent(contentData, fieldIds, trackableUrls, campaignState, unlayerTemplateData.PreviewImage);
 
             return new OkObjectResult($"La campaña '{campaignId}' del usuario '{accountName}' se guardó exitosamente ");
         }
 
-        private async Task SaveCampaignContent(BaseHtmlCampaignContentData contentData, IEnumerable<int> fieldIds, IEnumerable<string> trackableUrls, CampaignState campaignState)
+        private async Task SaveCampaignContent(BaseHtmlCampaignContentData contentData, IEnumerable<int> fieldIds, IEnumerable<string> trackableUrls, CampaignState campaignState, string previewImage)
         {
             var campaignIds = new[] { campaignState.IdCampaignA, campaignState.IdCampaignB }
                 .Where(x => x != null)
@@ -208,7 +200,7 @@ namespace Doppler.HtmlEditorApi.Controllers
                         whenIdCampaignIs: campaignId,
                         whenCurrentStepIs: 1);
                 }
-                await _campaignContentRepository.UpdateCampaignPreviewImage(campaignId, contentData.PreviewImage);
+                await _campaignContentRepository.UpdateCampaignPreviewImage(campaignId, previewImage);
                 await _campaignContentRepository.SaveNewFieldIds(campaignId, fieldIds);
                 await _campaignContentRepository.SaveLinks(campaignId, trackableUrls);
             }

--- a/Doppler.HtmlEditorApi/Domain/CampaignContentData.cs
+++ b/Doppler.HtmlEditorApi/Domain/CampaignContentData.cs
@@ -8,40 +8,31 @@ public sealed record EmptyCampaignContentData()
     : CampaignContentData();
 
 public sealed record UnknownCampaignContentData(
-    int CampaignId,
     string Content,
     string Head,
     string Meta,
-    int? EditorType,
-    string PreviewImage)
+    int? EditorType)
     : CampaignContentData();
 
 public sealed record MSEditorCampaignContentData(
-    int CampaignId,
     string Content)
     : CampaignContentData();
 
 public abstract record BaseHtmlCampaignContentData(
     string HtmlContent,
     string HtmlHead,
-    string PreviewImage,
-    string CampaignName,
     int? IdTemplate)
     : CampaignContentData();
 
 public sealed record HtmlCampaignContentData(
     string HtmlContent,
     string HtmlHead,
-    string PreviewImage,
-    string CampaignName,
     int? IdTemplate)
-    : BaseHtmlCampaignContentData(HtmlContent, HtmlHead, PreviewImage, CampaignName, IdTemplate);
+    : BaseHtmlCampaignContentData(HtmlContent, HtmlHead, IdTemplate);
 
 public sealed record UnlayerCampaignContentData(
     string HtmlContent,
     string HtmlHead,
     string Meta,
-    string PreviewImage,
-    string CampaignName,
     int? IdTemplate)
-    : BaseHtmlCampaignContentData(HtmlContent, HtmlHead, PreviewImage, CampaignName, IdTemplate);
+    : BaseHtmlCampaignContentData(HtmlContent, HtmlHead, IdTemplate);

--- a/Doppler.HtmlEditorApi/Domain/CampaignModel.cs
+++ b/Doppler.HtmlEditorApi/Domain/CampaignModel.cs
@@ -1,0 +1,7 @@
+namespace Doppler.HtmlEditorApi.Domain;
+
+public record CampaignModel(
+    int CampaignId,
+    string Name,
+    string PreviewImage,
+    CampaignContentData Content);

--- a/Doppler.HtmlEditorApi/Domain/TemplateContentData.cs
+++ b/Doppler.HtmlEditorApi/Domain/TemplateContentData.cs
@@ -7,14 +7,9 @@ public abstract record TemplateContentData()
 
 public sealed record UnlayerTemplateContentData(
     string HtmlComplete,
-    string Meta,
-    string PreviewImage,
-    string Name,
-    int EditorType,
-    bool IsPublic)
+    string Meta)
     : TemplateContentData();
 
 public sealed record UnknownTemplateContentData(
-    int EditorType,
-    bool IsPublic)
+    int EditorType)
     : TemplateContentData();

--- a/Doppler.HtmlEditorApi/Domain/TemplateModel.cs
+++ b/Doppler.HtmlEditorApi/Domain/TemplateModel.cs
@@ -1,0 +1,8 @@
+namespace Doppler.HtmlEditorApi.Domain;
+
+public record TemplateModel(
+    int TemplateId,
+    bool IsPublic,
+    string PreviewImage,
+    string Name,
+    TemplateContentData Content);

--- a/Doppler.HtmlEditorApi/Repositories.DopplerDb/DopplerTemplateRepository.cs
+++ b/Doppler.HtmlEditorApi/Repositories.DopplerDb/DopplerTemplateRepository.cs
@@ -18,23 +18,25 @@ public class DopplerTemplateRepository : ITemplateRepository
         _dbContext = dbContext;
     }
 
-    public async Task<TemplateContentData> GetTemplate(string accountName, int templateId)
+    public async Task<TemplateModel> GetTemplate(string accountName, int templateId)
     {
         var queryResult = await _dbContext.ExecuteAsync(new GetTemplateByIdWithStatusDbQuery(
             IdTemplate: templateId,
             AccountName: accountName
         ));
 
-        return queryResult == null ? null
-            : queryResult.EditorType == EditorTypeUnlayer ? new UnlayerTemplateContentData(
+        if (queryResult == null)
+        {
+            return null;
+        }
+
+        TemplateContentData content = queryResult.EditorType == EditorTypeUnlayer
+            ? new UnlayerTemplateContentData(
                 HtmlComplete: queryResult.HtmlCode,
-                Meta: queryResult.Meta,
-                PreviewImage: queryResult.PreviewImage,
-                Name: queryResult.Name,
-                EditorType: queryResult.EditorType,
-                IsPublic: queryResult.IsPublic)
+                Meta: queryResult.Meta)
             : new UnknownTemplateContentData(
-                EditorType: queryResult.EditorType,
-                IsPublic: queryResult.IsPublic);
+                EditorType: queryResult.EditorType);
+
+        return new TemplateModel(templateId, queryResult.IsPublic, queryResult.PreviewImage, queryResult.Name, content);
     }
 }

--- a/Doppler.HtmlEditorApi/Repositories/ICampaignContentRepository.cs
+++ b/Doppler.HtmlEditorApi/Repositories/ICampaignContentRepository.cs
@@ -7,7 +7,7 @@ namespace Doppler.HtmlEditorApi.Repositories;
 public interface ICampaignContentRepository
 {
     Task<CampaignState> GetCampaignState(string accountName, int campaignId);
-    Task<CampaignContentData> GetCampaignModel(string accountName, int campaignId);
+    Task<CampaignModel> GetCampaignModel(string accountName, int campaignId);
     Task CreateCampaignContent(int campaignId, CampaignContentData content);
     Task UpdateCampaignContent(int campaignId, CampaignContentData content);
 

--- a/Doppler.HtmlEditorApi/Repositories/ITemplateRepository.cs
+++ b/Doppler.HtmlEditorApi/Repositories/ITemplateRepository.cs
@@ -6,5 +6,5 @@ namespace Doppler.HtmlEditorApi.Repositories;
 
 public interface ITemplateRepository
 {
-    Task<TemplateContentData> GetTemplate(string accountName, int templateId);
+    Task<TemplateModel> GetTemplate(string accountName, int templateId);
 }


### PR DESCRIPTION
Hi team!

I think that we needed this code refactoring.

Now, content and campaign objects are two different things, it fixes our log time issue with preview images and also some new issues with the name. Now, `CampaignId`, `Name`, `PreviewImage` and `Content` are part of the `CampaignModel`.

I did the same with Templates, but I cannot reuse the same `Content` class because template content has a different structure merging `HtmlHead` and `HtmlContent` in the single field `HtmlComplete`.

To expose the data, the model is still being flattened in `CampaignContent`, we could consider this object like a _campaign's content + some campaign information_. For that reason, I have also removed `previewImage` field from `Content` class.

<img width="1111" alt="image" src="https://user-images.githubusercontent.com/1157864/198617190-c73ffac0-728a-4706-8fc8-668ebb34916a.png">

Could you review it?