### PR TITLE
chore(CodeQuality): add explicit formatProvider

### DIFF
--- a/Doppler.HtmlEditorApi/Domain/DopplerHtmlDocument.cs
+++ b/Doppler.HtmlEditorApi/Domain/DopplerHtmlDocument.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
 using HtmlAgilityPack;
@@ -61,7 +62,7 @@ public class DopplerHtmlDocument
 
     public IEnumerable<int> GetFieldIds()
         => FieldIdTagRegex.Matches(_contentNode.InnerHtml)
-            .Select(x => int.Parse(x.Groups[1].ValueSpan))
+            .Select(x => int.Parse(x.Groups[1].ValueSpan, provider: CultureInfo.InvariantCulture))
             .Distinct();
 
     public IEnumerable<string> GetTrackableUrls()
@@ -124,7 +125,7 @@ public class DopplerHtmlDocument
     {
         _contentNode.TraverseAndReplaceTextsAndAttributeValues(text => FieldIdTagRegex.Replace(
             text,
-            match => fieldIdExistFunc(int.Parse(match.Groups[1].ValueSpan))
+            match => fieldIdExistFunc(int.Parse(match.Groups[1].ValueSpan, provider: CultureInfo.InvariantCulture))
                 ? match.Value
                 : string.Empty));
     }

--- a/Doppler.HtmlEditorApi/Logging/SerilogSetup.cs
+++ b/Doppler.HtmlEditorApi/Logging/SerilogSetup.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Serilog;
@@ -16,7 +17,7 @@ namespace Doppler.HtmlEditorApi.Logging
             configuration.ConfigureLoggly(hostEnvironment);
 
             loggerConfiguration
-                .WriteTo.Console()
+                .WriteTo.Console(formatProvider: CultureInfo.InvariantCulture)
                 .Enrich.WithProperty("Application", hostEnvironment.ApplicationName)
                 .Enrich.WithProperty("Environment", hostEnvironment.EnvironmentName)
                 .Enrich.WithProperty("Platform", Environment.OSVersion.Platform)
@@ -26,7 +27,7 @@ namespace Doppler.HtmlEditorApi.Logging
             if (!hostEnvironment.IsDevelopment())
             {
                 loggerConfiguration
-                    .WriteTo.Loggly();
+                    .WriteTo.Loggly(formatProvider: CultureInfo.InvariantCulture);
             }
 
             loggerConfiguration.ReadFrom.Configuration(configuration);


### PR DESCRIPTION
Fix these errors:

```
Doppler.HtmlEditorApi/Logging/SerilogSetup.cs(18,13): error CA1305: The behavior of '{0}' could vary based on the current user's locale settings. Provide a value for the 'IFormatProvider' argument. [Doppler.HtmlEditorApi/Doppler.HtmlEditorApi.csproj]

Doppler.HtmlEditorApi/Domain/DopplerHtmlDocument.cs(64,26): error CA1305: The behavior of '{0}' could vary based on the current user's locale settings. Provide a value for the 'IFormatProvider' argument. [Doppler.HtmlEditorApi/Doppler.HtmlEditorApi.csproj]

Doppler.HtmlEditorApi/Logging/SerilogSetup.cs(28,17): error CA1305: The behavior of '{0}' could vary based on the current user's locale settings. Provide a value for the 'IFormatProvider' argument. [Doppler.HtmlEditorApi/Doppler.HtmlEditorApi.csproj]

Doppler.HtmlEditorApi/Domain/DopplerHtmlDocument.cs(127,39): error CA1305: The behavior of '{0}' could vary based on the current user's locale settings. Provide a value for the 'IFormatProvider' argument. [Doppler.HtmlEditorApi/Doppler.HtmlEditorApi.csproj]
```