### PR TITLE
Replace `async void` for `async Task`

### DIFF
--- a/Doppler.HtmlEditorApi.Test/Repositories.DopplerDb/DopplerCampaignContentRepositoryTest.cs
+++ b/Doppler.HtmlEditorApi.Test/Repositories.DopplerDb/DopplerCampaignContentRepositoryTest.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Doppler.HtmlEditorApi.DataAccess;
 using Doppler.HtmlEditorApi.Repositories.DopplerDb.Queries;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -32,7 +33,7 @@ public class DopplerCampaignContentRepositoryTest : IClassFixture<WebApplication
     [InlineData(20, false)]
     [InlineData(21, false)]
     [InlineData(22, false)]
-    public async void GetCampaignState_with_content_writable_when_valid_doppler_status_code(int? dopplerCampaignStatus, bool expectedIsWritable)
+    public async Task GetCampaignState_with_content_writable_when_valid_doppler_status_code(int? dopplerCampaignStatus, bool expectedIsWritable)
     {
         var dbContextMock = new Mock<IDbContext>();
         dbContextMock

--- a/Doppler.HtmlEditorApi.Test/Repositories.DopplerDb/DopplerTemplateRepositoryTest.cs
+++ b/Doppler.HtmlEditorApi.Test/Repositories.DopplerDb/DopplerTemplateRepositoryTest.cs
@@ -18,7 +18,7 @@ public class DopplerTemplateRepositoryTest : IClassFixture<WebApplicationFactory
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    public async void GetTemplate_unlayer_template(bool isPublicExpected)
+    public async Task GetTemplate_unlayer_template(bool isPublicExpected)
     {
         var dbContextMock = new Mock<IDbContext>();
         dbContextMock
@@ -47,7 +47,7 @@ public class DopplerTemplateRepositoryTest : IClassFixture<WebApplicationFactory
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    public async void Get_unknown_template(bool isPublicExpected)
+    public async Task Get_unknown_template(bool isPublicExpected)
     {
         var dbContextMock = new Mock<IDbContext>();
         dbContextMock


### PR DESCRIPTION
Although xUnit supports `async void` (see https://github.com/xunit/xunit/issues/1405), I think that we should try to avoid this construction.

What do you think?
