### PR TITLE
DE-901 - Support template creation

### DIFF
--- a/Doppler.HtmlEditorApi.Test/http/accounts/_/templates/_/GetTemplateTest.cs
+++ b/Doppler.HtmlEditorApi.Test/http/accounts/_/templates/_/GetTemplateTest.cs
@@ -284,6 +284,8 @@ public class GetTemplateTest : IClassFixture<WebApplicationFactory<Startup>>
 
         // Assert
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
-        Assert.Equal($"It is a public template, use /shared/templates/{idTemplate}", responseContent);
+        Assert.Contains($"\"detail\":\"It is a public template, use /shared/templates/{idTemplate}\"", responseContent);
+        Assert.Contains("\"title\":\"Not Found\"", responseContent);
+        Assert.Contains("\"status\":404", responseContent);
     }
 }

--- a/Doppler.HtmlEditorApi.Test/http/accounts/_/templates/_/GetTemplateTest.cs
+++ b/Doppler.HtmlEditorApi.Test/http/accounts/_/templates/_/GetTemplateTest.cs
@@ -195,11 +195,10 @@ public class GetTemplateTest : IClassFixture<WebApplicationFactory<Startup>>
         var responseContentJson = responseContentDoc.RootElement;
 
         // Assert
-        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
-        Assert.Equal("https://httpstatuses.io/500", responseContentJson.GetProperty("type").GetString());
-        Assert.Equal("Internal Server Error", responseContentJson.GetProperty("title").GetString());
+        Assert.Equal(HttpStatusCode.NotImplemented, response.StatusCode);
+        Assert.Equal("Not Implemented", responseContentJson.GetProperty("title").GetString());
         Assert.Equal("Unsupported template content type Doppler.HtmlEditorApi.Domain.UnknownTemplateContentData", responseContentJson.GetProperty("detail").GetString());
-        Assert.Equal(500, responseContentJson.GetProperty("status").GetInt32());
+        Assert.Equal(501, responseContentJson.GetProperty("status").GetInt32());
     }
 
     [Theory]

--- a/Doppler.HtmlEditorApi.Test/http/accounts/_/templates/_/PutTemplateTest.cs
+++ b/Doppler.HtmlEditorApi.Test/http/accounts/_/templates/_/PutTemplateTest.cs
@@ -232,7 +232,9 @@ public class PutTemplateTest : IClassFixture<WebApplicationFactory<Startup>>
 
         // Assert
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
-        Assert.Equal("Template not found, belongs to a different account, or it is a public template.", responseContent);
+        Assert.Contains("Template not found, belongs to a different account, or it is a public template", responseContent);
+        Assert.Contains("\"title\":\"Not Found\"", responseContent);
+        Assert.Contains("\"status\":404", responseContent);
     }
 
     [Fact]
@@ -273,7 +275,9 @@ public class PutTemplateTest : IClassFixture<WebApplicationFactory<Startup>>
 
         // Assert
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
-        Assert.Equal("Template not found, belongs to a different account, or it is a public template.", responseContent);
+        Assert.Contains("\"detail\":\"Template not found, belongs to a different account, or it is a public template.\"", responseContent);
+        Assert.Contains("\"title\":\"Not Found\"", responseContent);
+        Assert.Contains("\"status\":404", responseContent);
     }
 
     [Fact]

--- a/Doppler.HtmlEditorApi.Test/http/accounts/_/templates/_/from-template/_/PostTemplateFromTemplateTest.cs
+++ b/Doppler.HtmlEditorApi.Test/http/accounts/_/templates/_/from-template/_/PostTemplateFromTemplateTest.cs
@@ -1,0 +1,209 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Doppler.HtmlEditorApi.Domain;
+using Doppler.HtmlEditorApi.Repositories;
+using Doppler.HtmlEditorApi.Test.Utils;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Moq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Doppler.HtmlEditorApi;
+
+public class PostTemplateFromTemplateTest : IClassFixture<WebApplicationFactory<Startup>>
+{
+    private readonly WebApplicationFactory<Startup> _factory;
+    private readonly ITestOutputHelper _output;
+
+    public PostTemplateFromTemplateTest(WebApplicationFactory<Startup> factory, ITestOutputHelper output)
+    {
+        _factory = factory;
+        _output = output;
+    }
+
+    [Theory]
+    [InlineData("/accounts/x@x.com/templates/from-template/456", HttpStatusCode.Unauthorized)]
+    public async Task GET_template_should_require_token(string url, HttpStatusCode expectedStatusCode)
+    {
+        // Arrange
+        var client = _factory.CreateClient(new WebApplicationFactoryClientOptions());
+
+        // Act
+        var response = await client.PostAsync(url, null);
+        _output.WriteLine(response.GetHeadersAsString());
+
+        // Assert
+        Assert.Equal(expectedStatusCode, response.StatusCode);
+        Assert.Equal("Bearer", response.Headers.WwwAuthenticate.ToString());
+    }
+
+    [Theory]
+    [InlineData("/accounts/x@x.com/templates/from-template/456", TestUsersData.TOKEN_TEST1_EXPIRE_20330518, HttpStatusCode.Forbidden)]
+    [InlineData("/accounts/x@x.com/templates/from-template/456", TestUsersData.TOKEN_EXPIRE_20330518, HttpStatusCode.Forbidden)]
+    public async Task GET_template_should_not_accept_the_token_of_another_account(string url, string token, HttpStatusCode expectedStatusCode)
+    {
+        // Arrange
+        var client = _factory.CreateClient(new WebApplicationFactoryClientOptions());
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        // Act
+        var response = await client.PostAsync(url, null);
+        _output.WriteLine(response.GetHeadersAsString());
+
+        // Assert
+        Assert.Equal(expectedStatusCode, response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData($"/accounts/{TestUsersData.EMAIL_TEST1}/templates/from-template/456", TestUsersData.TOKEN_TEST1_EXPIRE_20010908, HttpStatusCode.Unauthorized)]
+    [InlineData($"/accounts/{TestUsersData.EMAIL_TEST1}/templates/from-template/456", TestUsersData.TOKEN_SUPERUSER_EXPIRE_20010908, HttpStatusCode.Unauthorized)]
+    public async Task GET_template_should_not_accept_a_expired_token(string url, string token, HttpStatusCode expectedStatusCode)
+    {
+        // Arrange
+        var client = _factory.CreateClient(new WebApplicationFactoryClientOptions());
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        // Act
+        var response = await client.PostAsync(url, null);
+        _output.WriteLine(response.GetHeadersAsString());
+
+        // Assert
+        Assert.Equal(expectedStatusCode, response.StatusCode);
+        Assert.Contains("Bearer", response.Headers.WwwAuthenticate.ToString());
+        Assert.Contains("invalid_token", response.Headers.WwwAuthenticate.ToString());
+        Assert.Contains("token expired", response.Headers.WwwAuthenticate.ToString());
+    }
+
+    [Theory]
+    [InlineData($"/accounts/{TestUsersData.EMAIL_TEST1}/templates/from-template/459", TestUsersData.TOKEN_TEST1_EXPIRE_20330518, TestUsersData.EMAIL_TEST1, 459)]
+    [InlineData($"/accounts/{TestUsersData.EMAIL_TEST1}/templates/from-template/459", TestUsersData.TOKEN_SUPERUSER_EXPIRE_20330518, TestUsersData.EMAIL_TEST1, 459)]
+    [InlineData("/accounts/otro@test.com/templates/from-template/459", TestUsersData.TOKEN_SUPERUSER_EXPIRE_20330518, "otro@test.com", 459)]
+    public async Task GET_template_should_accept_right_tokens_and_return_404_when_not_exist(string url, string token, string accountName, int baseTemplateId)
+    {
+        // Arrange
+        TemplateModel templateModel = null;
+        var repositoryMock = new Mock<ITemplateRepository>();
+
+        repositoryMock
+            .Setup(x => x.GetOwnOrPublicTemplate(accountName, baseTemplateId))
+            .ReturnsAsync(templateModel);
+
+        var client = _factory.CreateSutClient(
+            serviceToOverride1: repositoryMock.Object,
+            token: token);
+
+        // Act
+        var response = await client.PostAsync(url, null);
+        _output.WriteLine(response.GetHeadersAsString());
+
+        // Assert
+        repositoryMock.VerifyAll();
+        repositoryMock.VerifyNoOtherCalls();
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData($"/accounts/{TestUsersData.EMAIL_TEST1}/templates/from-template/459", TestUsersData.TOKEN_TEST1_EXPIRE_20330518, TestUsersData.EMAIL_TEST1, 459)]
+    [InlineData($"/accounts/{TestUsersData.EMAIL_TEST1}/templates/from-template/459", TestUsersData.TOKEN_SUPERUSER_EXPIRE_20330518, TestUsersData.EMAIL_TEST1, 459)]
+    [InlineData("/accounts/otro@test.com/templates/from-template/459", TestUsersData.TOKEN_SUPERUSER_EXPIRE_20330518, "otro@test.com", 459)]
+    public async Task GET_template_should_accept_right_tokens_and_call_repository_and_return_createdResourceId(string url, string token, string accountName, int baseTemplateId)
+    {
+        // Arrange
+        var newTemplateId = 5;
+        var expectedSchemaVersion = 999;
+        var isPublic = true;
+        var previewImage = "PreviewImage";
+        var name = "Name";
+        var contentData = new UnlayerTemplateContentData(
+            HtmlComplete: "<html></html>",
+            Meta: JsonSerializer.Serialize(new
+            {
+                schemaVersion = expectedSchemaVersion
+            }));
+
+        var templateModel = new TemplateModel(
+            TemplateId: baseTemplateId,
+            IsPublic: isPublic,
+            PreviewImage: previewImage,
+            Name: name,
+            Content: contentData);
+
+        var repositoryMock = new Mock<ITemplateRepository>();
+
+        repositoryMock
+            .Setup(x => x.GetOwnOrPublicTemplate(accountName, baseTemplateId))
+            .ReturnsAsync(templateModel);
+
+        repositoryMock
+            .Setup(x => x.CreatePrivateTemplate(
+                accountName,
+                It.Is<TemplateModel>(t =>
+                    t != templateModel
+                    && !t.IsPublic
+                    && t.TemplateId == 0)))
+            .ReturnsAsync(newTemplateId);
+
+        var client = _factory.CreateSutClient(
+            serviceToOverride1: repositoryMock.Object,
+            token: token);
+
+        // Act
+        var response = await client.PostAsync(url, null);
+        var headers = response.GetHeadersAsString();
+        var responseContent = await response.Content.ReadAsStringAsync();
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        repositoryMock.VerifyAll();
+        repositoryMock.VerifyNoOtherCalls();
+        Assert.Matches("""{"createdResourceId":5}""", responseContent);
+        Assert.Contains($"Location: http://localhost/accounts/{accountName}/templates/{newTemplateId}", headers);
+    }
+
+    [Theory]
+    [InlineData($"/accounts/{TestUsersData.EMAIL_TEST1}/templates/from-template/459", TestUsersData.TOKEN_TEST1_EXPIRE_20330518, TestUsersData.EMAIL_TEST1, 459)]
+    public async Task GET_template_should_error_when_base_template_content_is_mseditor(string url, string token, string accountName, int baseTemplateId)
+    {
+        // Arrange
+        var editorType = 4;
+        var isPublic = true;
+        var previewImage = "PreviewImage";
+        var name = "Name";
+        var contentData = new UnknownTemplateContentData(editorType);
+
+        var templateModel = new TemplateModel(
+            TemplateId: baseTemplateId,
+            IsPublic: isPublic,
+            PreviewImage: previewImage,
+            Name: name,
+            Content: contentData);
+
+        var repositoryMock = new Mock<ITemplateRepository>();
+
+        repositoryMock
+            .Setup(x => x.GetOwnOrPublicTemplate(accountName, baseTemplateId))
+            .ReturnsAsync(templateModel);
+
+        var client = _factory.CreateSutClient(
+            serviceToOverride1: repositoryMock.Object,
+            token: token);
+
+        // Act
+        var response = await client.PostAsync(url, null);
+        _output.WriteLine(response.GetHeadersAsString());
+        var responseContent = await response.Content.ReadAsStringAsync();
+        using var responseContentDoc = JsonDocument.Parse(responseContent);
+        var responseContentJson = responseContentDoc.RootElement;
+
+        // Assert
+        repositoryMock.VerifyAll();
+        repositoryMock.VerifyNoOtherCalls();
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+        Assert.Equal("https://httpstatuses.io/500", responseContentJson.GetProperty("type").GetString());
+        Assert.Equal("Internal Server Error", responseContentJson.GetProperty("title").GetString());
+        Assert.Equal("Unsupported template content type Doppler.HtmlEditorApi.Domain.UnknownTemplateContentData", responseContentJson.GetProperty("detail").GetString());
+        Assert.Equal(500, responseContentJson.GetProperty("status").GetInt32());
+    }
+}

--- a/Doppler.HtmlEditorApi/ApiModels/ResourceCreated.cs
+++ b/Doppler.HtmlEditorApi/ApiModels/ResourceCreated.cs
@@ -1,0 +1,3 @@
+namespace Doppler.HtmlEditorApi.ApiModels;
+
+public record ResourceCreated(int createdResourceId);

--- a/Doppler.HtmlEditorApi/Repositories.DopplerDb/DopplerTemplateRepository.cs
+++ b/Doppler.HtmlEditorApi/Repositories.DopplerDb/DopplerTemplateRepository.cs
@@ -59,4 +59,19 @@ public class DopplerTemplateRepository : ITemplateRepository
 
         await _dbContext.ExecuteAsync(updateTemplateQuery);
     }
+
+    public Task<int> CreatePrivateTemplate(string accountName, TemplateModel templateModel)
+    {
+        // To avoid ambiguities
+        if (templateModel.TemplateId > 0)
+        {
+            throw new ArgumentException("TemplateId should not be set to create a new private template", nameof(templateModel));
+        }
+        if (templateModel.IsPublic)
+        {
+            throw new ArgumentException("IsPublic should be false to create a new private template", nameof(templateModel));
+        }
+
+        throw new NotImplementedException();
+    }
 }

--- a/Doppler.HtmlEditorApi/Repositories.DopplerDb/Queries/CreatePrivateTemplateDbQuery.cs
+++ b/Doppler.HtmlEditorApi/Repositories.DopplerDb/Queries/CreatePrivateTemplateDbQuery.cs
@@ -1,0 +1,33 @@
+using Doppler.HtmlEditorApi.DataAccess;
+
+namespace Doppler.HtmlEditorApi.Repositories.DopplerDb.Queries;
+
+public record CreatePrivateTemplateDbQuery(
+    string AccountName,
+    int? EditorType,
+    string HtmlCode,
+    string Meta,
+    string PreviewImage,
+    string Name
+) : ISingleItemDbQuery<CreatePrivateTemplateDbQuery.Result>
+{
+    public string GenerateSqlQuery() => $"""
+        INSERT INTO Template (IdUser, EditorType, HtmlCode, Meta, PreviewImage, Name, Active)
+        OUTPUT INSERTED.idTemplate AS NewTemplateId
+        SELECT
+            u.IdUser AS IdUser,
+            @EditorType AS EditorType,
+            @HtmlCode AS HtmlCode,
+            @Meta AS Meta,
+            @PreviewImage AS PreviewImage,
+            @Name AS Name,
+            1 AS Active
+        FROM [User] u
+        WHERE u.Email = @AccountName
+        """;
+
+    public class Result
+    {
+        public int NewTemplateId { get; init; }
+    }
+}

--- a/Doppler.HtmlEditorApi/Repositories/ITemplateRepository.cs
+++ b/Doppler.HtmlEditorApi/Repositories/ITemplateRepository.cs
@@ -7,4 +7,5 @@ public interface ITemplateRepository
 {
     Task<TemplateModel> GetOwnOrPublicTemplate(string accountName, int templateId);
     Task UpdateTemplate(TemplateModel templateModel);
+    Task<int> CreatePrivateTemplate(string accountName, TemplateModel templateModel);
 }


### PR DESCRIPTION
Hi team!

These changes allow us to create templates based on another template.

Related to https://github.com/MakingSense/Doppler/pull/9883

There are some refactorings in this PR because [I learn about TypedResults](https://devblogs.microsoft.com/dotnet/asp-net-core-updates-in-dotnet-7-preview-4/#typed-results-for-minimal-apis) and I really liked them. In following steps I will be migrating all the API from `IActionResult` to typed `IResult`.

Could you review?