### PR TITLE
DBG-209 - Set ContentType in Automation Unlayer campaigns

### DIFF
--- a/Doppler.HtmlEditorApi.Test/Repositories.DopplerDb/Queries/UpdateCampaignStatusDbQueryTest.cs
+++ b/Doppler.HtmlEditorApi.Test/Repositories.DopplerDb/Queries/UpdateCampaignStatusDbQueryTest.cs
@@ -1,0 +1,43 @@
+using Xunit;
+
+namespace Doppler.HtmlEditorApi.Repositories.DopplerDb.Queries;
+
+public class UpdateCampaignStatusDbQueryTest
+{
+    [Fact]
+    public void UpdateCampaignStatusDbQuery_should_update_campaign_when_desired_step()
+    {
+        // Arrange
+        var idCampaign = 567;
+        var oldStep = 1;
+        var newStep = 2;
+        var newHtmlSourceType = 3;
+
+        var dbQuery = new UpdateCampaignStatusDbQuery(
+            SetCurrentStep: newStep,
+            SetHtmlSourceType: newHtmlSourceType,
+            WhenIdCampaignIs: idCampaign,
+            WhenCurrentStepIs: oldStep
+        );
+
+        var expectedQuery = """
+            UPDATE Campaign
+            SET
+                CurrentStep = @setCurrentStep,
+                HtmlSourceType = @setHtmlSourceType
+            WHERE
+                IdCampaign = @whenIdCampaignIs
+                AND CurrentStep = @whenCurrentStepIs
+            """;
+
+        // Act
+        var sqlQuery = dbQuery.GenerateSqlQuery();
+
+        // Assert
+        Assert.Equal(expectedQuery, sqlQuery);
+        Assert.Equal(idCampaign, dbQuery.WhenIdCampaignIs);
+        Assert.Equal(oldStep, dbQuery.WhenCurrentStepIs);
+        Assert.Equal(newStep, dbQuery.SetCurrentStep);
+        Assert.Equal(newHtmlSourceType, dbQuery.SetHtmlSourceType);
+    }
+}

--- a/Doppler.HtmlEditorApi.Test/Repositories.DopplerDb/Queries/UpdateCampaignStatusDbQueryTest.cs
+++ b/Doppler.HtmlEditorApi.Test/Repositories.DopplerDb/Queries/UpdateCampaignStatusDbQueryTest.cs
@@ -12,10 +12,12 @@ public class UpdateCampaignStatusDbQueryTest
         var oldStep = 1;
         var newStep = 2;
         var newHtmlSourceType = 3;
+        var newContentType = 4;
 
         var dbQuery = new UpdateCampaignStatusDbQuery(
             SetCurrentStep: newStep,
             SetHtmlSourceType: newHtmlSourceType,
+            SetContentType: newContentType,
             WhenIdCampaignIs: idCampaign,
             WhenCurrentStepIs: oldStep
         );
@@ -24,7 +26,8 @@ public class UpdateCampaignStatusDbQueryTest
             UPDATE Campaign
             SET
                 CurrentStep = @setCurrentStep,
-                HtmlSourceType = @setHtmlSourceType
+                HtmlSourceType = @setHtmlSourceType,
+                ContentType = @setContentType
             WHERE
                 IdCampaign = @whenIdCampaignIs
                 AND CurrentStep = @whenCurrentStepIs

--- a/Doppler.HtmlEditorApi.Test/http/accounts/_/campaings/_/content/PutCampaignTest.cs
+++ b/Doppler.HtmlEditorApi.Test/http/accounts/_/campaings/_/content/PutCampaignTest.cs
@@ -713,6 +713,7 @@ public class PutCampaignTest : IClassFixture<WebApplicationFactory<Startup>>
 
         var setCurrentStep = 2;
         var setHtmlSourceType = 2;
+        var setContentType = 2;
         var whenCurrentStepIs = 1;
         var whenIdCampaignIs = expectedIdCampaign;
         dbContextMock
@@ -720,6 +721,7 @@ public class PutCampaignTest : IClassFixture<WebApplicationFactory<Startup>>
                 new UpdateCampaignStatusDbQuery(
                     setCurrentStep,
                     setHtmlSourceType,
+                    setContentType,
                     whenIdCampaignIs,
                     whenCurrentStepIs)))
             .ReturnsAsync(1);

--- a/Doppler.HtmlEditorApi.Test/http/accounts/_/campaings/_/content/from-template/_/CreateCampaignContentFromTemplateTest.cs
+++ b/Doppler.HtmlEditorApi.Test/http/accounts/_/campaings/_/content/from-template/_/CreateCampaignContentFromTemplateTest.cs
@@ -652,6 +652,7 @@ public class CreateCampaignContentFromTemplateTest : IClassFixture<WebApplicatio
 
         var setCurrentStep = 2;
         var setHtmlSourceType = 2;
+        var setContentType = 2;
         var whenCurrentStepIs = 1;
         var whenIdCampaignIs = idCampaign;
         dbContextMock
@@ -659,6 +660,7 @@ public class CreateCampaignContentFromTemplateTest : IClassFixture<WebApplicatio
                 new UpdateCampaignStatusDbQuery(
                     setCurrentStep,
                     setHtmlSourceType,
+                    setContentType,
                     whenIdCampaignIs,
                     whenCurrentStepIs)))
             .ReturnsAsync(1);

--- a/Doppler.HtmlEditorApi/Controllers/CampaignsController.cs
+++ b/Doppler.HtmlEditorApi/Controllers/CampaignsController.cs
@@ -43,6 +43,7 @@ namespace Doppler.HtmlEditorApi.Controllers
         // We are using HTMLSourceType = 2 (Template) because Editor seems to be tied to the old HTML Editor
         // See https://github.com/MakingSense/Doppler/blob/48cf637bb1f8b4d81837fff904d8736fe889ff1c/Doppler.Transversal/Classes/CampaignHTMLContentTypeEnum.cs#L12-L17
         private const int TemplateHtmlSourceType = 2;
+        private const int HtmlContentType = 2;
 
         public CampaignsController(ICampaignContentRepository repository, IFieldsRepository fieldsRepository, IOptions<FieldsOptions> fieldsOptions, ITemplateRepository templateRepository)
         {
@@ -199,6 +200,7 @@ namespace Doppler.HtmlEditorApi.Controllers
                     await _campaignContentRepository.UpdateCampaignStatus(
                         setCurrentStep: 2,
                         setHtmlSourceType: TemplateHtmlSourceType,
+                        setContentType: HtmlContentType,
                         whenIdCampaignIs: campaignId,
                         whenCurrentStepIs: 1);
                 }
@@ -212,6 +214,7 @@ namespace Doppler.HtmlEditorApi.Controllers
                 await _campaignContentRepository.UpdateCampaignStatus(
                     setCurrentStep: 2,
                     setHtmlSourceType: TemplateHtmlSourceType,
+                    setContentType: HtmlContentType,
                     whenIdCampaignIs: campaignState.IdCampaignResult.Value,
                     whenCurrentStepIs: 1);
             }

--- a/Doppler.HtmlEditorApi/Repositories.DopplerDb/DopplerCampaignContentRepository.cs
+++ b/Doppler.HtmlEditorApi/Repositories.DopplerDb/DopplerCampaignContentRepository.cs
@@ -177,11 +177,17 @@ public class DopplerCampaignContentRepository : ICampaignContentRepository
         await _dbContext.ExecuteAsync(new DeleteRemovedCampaignLinks(contentId, links));
     }
 
-    public async Task UpdateCampaignStatus(int setCurrentStep, int setHtmlSourceType, int whenIdCampaignIs, int whenCurrentStepIs)
+    public async Task UpdateCampaignStatus(
+        int setCurrentStep,
+        int setHtmlSourceType,
+        int setContentType,
+        int whenIdCampaignIs,
+        int whenCurrentStepIs)
     {
         var updateCampaignStatusQuery = new UpdateCampaignStatusDbQuery(
             setCurrentStep,
             setHtmlSourceType,
+            setContentType,
             whenIdCampaignIs,
             whenCurrentStepIs);
         await _dbContext.ExecuteAsync(updateCampaignStatusQuery);

--- a/Doppler.HtmlEditorApi/Repositories.DopplerDb/Queries/UpdateCampaignStatusDbQuery.cs
+++ b/Doppler.HtmlEditorApi/Repositories.DopplerDb/Queries/UpdateCampaignStatusDbQuery.cs
@@ -5,6 +5,7 @@ namespace Doppler.HtmlEditorApi.Repositories.DopplerDb.Queries;
 public record UpdateCampaignStatusDbQuery(
     int SetCurrentStep,
     int? SetHtmlSourceType,
+    int SetContentType,
     int WhenIdCampaignIs,
     int WhenCurrentStepIs
 ) : IExecutableDbQuery
@@ -13,7 +14,8 @@ public record UpdateCampaignStatusDbQuery(
         UPDATE Campaign
         SET
             CurrentStep = @setCurrentStep,
-            HtmlSourceType = @setHtmlSourceType
+            HtmlSourceType = @setHtmlSourceType,
+            ContentType = @setContentType
         WHERE
             IdCampaign = @whenIdCampaignIs
             AND CurrentStep = @whenCurrentStepIs

--- a/Doppler.HtmlEditorApi/Repositories.DopplerDb/Queries/UpdateCampaignStatusDbQuery.cs
+++ b/Doppler.HtmlEditorApi/Repositories.DopplerDb/Queries/UpdateCampaignStatusDbQuery.cs
@@ -9,13 +9,13 @@ public record UpdateCampaignStatusDbQuery(
     int WhenCurrentStepIs
 ) : IExecutableDbQuery
 {
-    public string GenerateSqlQuery() => @"
-UPDATE Campaign
-SET
-    CurrentStep = @setCurrentStep,
-    HtmlSourceType = @setHtmlSourceType
-WHERE
-    IdCampaign = @whenIdCampaignIs
-    AND CurrentStep = @whenCurrentStepIs";
-
+    public string GenerateSqlQuery() => """
+        UPDATE Campaign
+        SET
+            CurrentStep = @setCurrentStep,
+            HtmlSourceType = @setHtmlSourceType
+        WHERE
+            IdCampaign = @whenIdCampaignIs
+            AND CurrentStep = @whenCurrentStepIs
+        """;
 }

--- a/Doppler.HtmlEditorApi/Repositories/ICampaignContentRepository.cs
+++ b/Doppler.HtmlEditorApi/Repositories/ICampaignContentRepository.cs
@@ -21,6 +21,11 @@ public interface ICampaignContentRepository
     /// It does not update the properties of existing links that are also in the payload.
     /// </summary>
     Task SaveLinks(int contentId, IEnumerable<string> links);
-    Task UpdateCampaignStatus(int setCurrentStep, int setHtmlSourceType, int whenIdCampaignIs, int whenCurrentStepIs);
+    Task UpdateCampaignStatus(
+        int setCurrentStep,
+        int setHtmlSourceType,
+        int setContentType,
+        int whenIdCampaignIs,
+        int whenCurrentStepIs);
     Task UpdateCampaignPreviewImage(int campaignId, string previewImage);
 }


### PR DESCRIPTION
When Automation campaigns are in the _step 1_, his _ContentType is 0_ (undefined), while in the regular campaigns, it is 1 (text) or 2 (HTML).

These changes allow us to deal with this scenario.