### PR TITLE
DOP-1397 - add sanitize content for dynamic component

### DIFF
--- a/Doppler.HtmlEditorApi.Test/Domain/DopplerHtmlDocumentTest.cs
+++ b/Doppler.HtmlEditorApi.Test/Domain/DopplerHtmlDocumentTest.cs
@@ -261,6 +261,7 @@ shareArticle?mini=true&amp;url=https%3a%2f%2fvp.mydplr.com%2f123&amp;title=Prueb
     }
 
     [Fact]
+
     public void GetTrackableUrls_should_return_list_of_trackable_urls()
     {
         // Arrange
@@ -306,6 +307,67 @@ shareArticle?mini=true&amp;url=https%3a%2f%2fvp.mydplr.com%2f123&amp;title=Prueb
             link => Assert.Equal("www.GOOGLE.com/[[[field]]]", link),
             link => Assert.Equal("ftp://|*|3*|*", link));
     }
+
+    [Fact]
+    public void SanitizeDynamicContentNode_should_modify_html_dynamic_content_when_has_two_or_more_child_node_and_replace_image_src()
+    {
+        // Arrange
+        var input = $@"<dynamiccontent action=""abandoned_cart"" items=""2"">
+    <div role=""container"">
+        <section>
+            <a role=""link"" href=""[[[DC:URL]]]"" target=""_blank"">
+                <img
+                    src=""https://cdn.fromdoppler.com/unlayer-editor/assets/cart_v2.svg""
+                    alt=""product image""
+                />
+            </a>
+        </section>
+        <section>
+            <span>[[[DC:TITLE]]]</span>
+            <span >[[[DC:PRICE]]]</span>
+            <a role=""link"" href=""[[[DC:URL]]]"" target=""_blank"">Comprar</a>
+        </section>
+    </div>
+    <div role=""container"">
+        <section>
+            <a role=""link"" href=""[[[DC:URL]]]"" target=""_blank"">
+                <img
+                    src=""https://cdn.fromdoppler.com/unlayer-editor/assets/cart_v2.svg""
+                    alt=""product image""
+                />
+            </a>
+        </section>
+        <section>
+            <span>[[[DC:TITLE]]]</span>
+            <span >[[[DC:PRICE]]]</span>
+            <a role=""link"" href=""[[[DC:URL]]]"" target=""_blank"">Comprar</a>
+        </section>
+    </div></dynamiccontent>";
+        var htmlDocument = new DopplerHtmlDocument(input);
+        htmlDocument.GetDopplerContent();
+        var sanitizedContent = $@"<dynamiccontent action=""abandoned_cart"" items=""2"">
+    <div role=""container"">
+        <section>
+            <a role=""link"" href=""[[[DC:URL]]]"" target=""_blank"">
+                <img src=""[[[DC:IMAGE]]]"" alt=""product image"">
+            </a>
+        </section>
+        <section>
+            <span>[[[DC:TITLE]]]</span>
+            <span>[[[DC:PRICE]]]</span>
+            <a role=""link"" href=""[[[DC:URL]]]"" target=""_blank"">Comprar</a>
+        </section>
+    </div>
+    </dynamiccontent>";
+
+        // Act
+        htmlDocument.SanitizeDynamicContentNode();
+        var content = htmlDocument.GetDopplerContent();
+
+        // Assert
+        Assert.Equal(sanitizedContent, content);
+    }
+
 
     [Fact]
     public void GetTrackableUrls_remove_encoding_on_sanitize_to_save()

--- a/Doppler.HtmlEditorApi/Controllers/CampaignsController.cs
+++ b/Doppler.HtmlEditorApi/Controllers/CampaignsController.cs
@@ -236,6 +236,7 @@ namespace Doppler.HtmlEditorApi.Controllers
             htmlDocument.ReplaceFieldNameTagsByFieldIdTags(dopplerFieldsProcessor.GetFieldIdOrNull);
             htmlDocument.RemoveUnknownFieldIdTags(dopplerFieldsProcessor.FieldIdExist);
             htmlDocument.SanitizeTrackableLinks();
+            htmlDocument.SanitizeDynamicContentNode();
             return htmlDocument;
         }
 

--- a/Doppler.HtmlEditorApi/Domain/DopplerHtmlDocument.cs
+++ b/Doppler.HtmlEditorApi/Domain/DopplerHtmlDocument.cs
@@ -89,6 +89,30 @@ public class DopplerHtmlDocument
         }
     }
 
+    /// <summary>
+    /// Sanitize the HTML code exported by Unlayer for the right processing of Doppler.
+    /// - Remove repeated cart item tags
+    /// - Replace img src value by [[[DC:IMAGE]]]
+    /// </summary>
+    public void SanitizeDynamicContentNode()
+    {
+        var dynamicContentNode = _contentNode.SelectSingleNode("//dynamiccontent");
+        if (dynamicContentNode != null)
+        {
+            var divNodes = dynamicContentNode.SelectNodes("div");
+            if (divNodes != null && divNodes.Count > 1)
+            {
+                for (var i = 1; i < divNodes.Count; i++)
+                {
+                    dynamicContentNode.RemoveChild(divNodes[i]);
+                }
+            }
+
+            var imgNode = dynamicContentNode.SelectSingleNode(".//img");
+            imgNode?.SetAttributeValue("src", "[[[DC:IMAGE]]]");
+        }
+    }
+
     public void RemoveHarmfulTags()
     {
         var harmfulTags = _rootNode.SelectNodes(@"//script|//embed|//iframe|//meta[contains(@http-equiv,'refresh')]").EmptyIfNull();

--- a/cspell-project-words.txt
+++ b/cspell-project-words.txt
@@ -25,6 +25,7 @@ dplr
 mseditor
 mydplr
 socialshare
+dynamiccontent
 
 # Technical terms
 Liskov


### PR DESCRIPTION
Add process to adapt dynamic content to automation HTML syntactic rules

- remove redundant cart items (html nodes)
- replace img src by [[[DC:IMAGE]]]


