### PR TITLE
fix: do not set attribute if data dc type is present

### DIFF
--- a/Doppler.HtmlEditorApi/Domain/DopplerHtmlDocument.cs
+++ b/Doppler.HtmlEditorApi/Domain/DopplerHtmlDocument.cs
@@ -110,7 +110,10 @@ public class DopplerHtmlDocument
                     }
                 }
                 var imgNode = dynamicContentNodes[i].SelectSingleNode(".//img");
-                imgNode?.SetAttributeValue("src", "[[[DC:IMAGE]]]");
+                if (imgNode != null && imgNode.GetAttributeValue("data-dc-type", null) == null)
+                {
+                    imgNode.SetAttributeValue("src", "[[[DC:IMAGE]]]");
+                }
             }
         }
     }


### PR DESCRIPTION
Si el nodo DynamicContent tiene presente el atributo "data-dc-type" no debería realizar el siguiente seteo:

```imgNode.SetAttributeValue("src", "[[[DC:IMAGE]]]");```